### PR TITLE
Maintain newlines in abstract(html writer), #37

### DIFF
--- a/lib/adiwg/mdtranslator/writers/html/sections/html_inlineCss.css
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_inlineCss.css
@@ -72,6 +72,7 @@
 
         pre, code, kbd, samp { color: #000; font-family: monospace, monospace; _font-family: 'courier new', monospace; font-size: 0.98em; }
         pre { white-space: pre-wrap; word-wrap: break-word; }
+        .pre-line { white-space: pre-line; }
 
         b, strong { font-weight: bold; }
 

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_resourceGeneral.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_resourceGeneral.rb
@@ -90,10 +90,7 @@ module ADIWG
                         # general - abstract - required
                         @html.details do
                             @html.summary('Abstract', {'id'=>'resourceGen-abstract', 'class'=>'h4'})
-                            @html.section(:class=>'block') do
-                                @html.text!(resourceInfo[:abstract])
-                            end
-                            @html.br
+                            @html.tag!("section",resourceInfo[:abstract], :class=>'block pre-line')
                         end
 
                         # general - purpose


### PR DESCRIPTION
Add pre-line class to CSS and abstract section
Re-factor to remove new-line introduced by !text, use !tag instead