### PR TITLE
Fix for JRuby 

### DIFF
--- a/lib/adiwg/mdtranslator/readers/mdJson/modules_v1/module_contacts.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules_v1/module_contacts.rb
@@ -118,7 +118,7 @@ module ADIWG
                         # address
                         if hContact.has_key?('address')
                             conAddress = hContact['address']
-                            hAddress = $ReaderNS::Address.unpack(conAddress, responseObj)
+                            hAddress = Address.unpack(conAddress, responseObj)
                             unless hAddress.nil?
                                 intCont[:address] = hAddress
                             end


### PR DESCRIPTION
Fix for a jruby issue.

Using the global object ($ReaderNS) gives a 'is not a type/class' error when running on JRuby 9.1.6.0.  Verified that the tests are all happy with the change.  It's unclear why $ReaderNS is being used, so feel free to let me know if I missed something.  

Mark Hannon (at USGS Fort) is putting together a war file wrapping mdTranslator-rails (using Warbler) to allow running in a Servlet container, and I was helping him out.  Running the war was giving the 'is not a type/class' error on the mdTranslator-rails demo data.  The mdTranslator tests also failed when running against jruby 9.1.6.0.