### PR TITLE
Deprecate 'topicCategory' from mdJson 2.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,15 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
-# Rake::TestTask.new do |t|
-# 	t.libs << 'test'
-# 	t.test_files = FileList[
-# 		'test/readers/mdJson/tc*.rb',
-# 		'test/writers/iso19115-2/tc*.rb',
-# 		'test/writers/iso19110/tc*.rb',
-# 		'test/writers/mdJson/tc*.rb',
-# 		'test/writers/sbJson/tc*.rb',
-# 		'test/translator/tc*.rb'
-# 	]
-# 	t.verbose = true
-# end
-
 Rake::TestTask.new do |t|
 	t.libs << 'test'
 	t.test_files = FileList[
-		'test/writers/sbJson/tc*.rb'
+		'test/readers/mdJson/tc*.rb',
+		'test/writers/iso19115-2/tc*.rb',
+		'test/writers/iso19110/tc*.rb',
+		'test/writers/mdJson/tc*.rb',
+		'test/writers/sbJson/tc*.rb',
+		'test/translator/tc*.rb'
 	]
 	t.verbose = true
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,23 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
+# Rake::TestTask.new do |t|
+# 	t.libs << 'test'
+# 	t.test_files = FileList[
+# 		'test/readers/mdJson/tc*.rb',
+# 		'test/writers/iso19115-2/tc*.rb',
+# 		'test/writers/iso19110/tc*.rb',
+# 		'test/writers/mdJson/tc*.rb',
+# 		'test/writers/sbJson/tc*.rb',
+# 		'test/translator/tc*.rb'
+# 	]
+# 	t.verbose = true
+# end
+
 Rake::TestTask.new do |t|
 	t.libs << 'test'
 	t.test_files = FileList[
-		'test/readers/mdJson/tc*.rb',
-		'test/writers/iso19115-2/tc*.rb',
-		'test/writers/iso19110/tc*.rb',
-		'test/writers/mdJson/tc*.rb',
-		'test/translator/tc*.rb'
+		'test/writers/sbJson/tc*.rb'
 	]
 	t.verbose = true
 end

--- a/adiwg-mdtranslator.gemspec
+++ b/adiwg-mdtranslator.gemspec
@@ -1,39 +1,40 @@
 # coding: utf-8
+# History
+#  Stan Smith 2017-05-16 remove rgeo 0.5 support
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'adiwg/mdtranslator/version'
 
 Gem::Specification.new do |spec|
-    spec.name = "adiwg-mdtranslator"
-    spec.version = ADIWG::Mdtranslator::VERSION
-    spec.authors = ["Stan Smith", "Josh Bradley"]
-    spec.email = ["stansmith@usgs.gov", "joshua_bradley@fws.gov"]
-    spec.summary = %q{The mdtranslator (metadata translator) is a tool for translating metadata in one format to another. The tool is written and maintained by the Alaska Data Integration Working Group (ADIwg).}
-    spec.description = %q{The mdtranslator was written by the Alaska Data Integration Working Group (ADIwg) to assist with creating ISO 19139 metadata records.  Input to the mdtranslator is JSON conforming to the mdJson-schema.  The mdtranslator architecture allows developers to write additional readers for other input formats and/or write additional writers for other output other than ISO 19139.}
-    spec.homepage = "http://www.adiwg.org/mdTranslator"
-    spec.license = "UNLICENSED"
+   spec.name = "adiwg-mdtranslator"
+   spec.version = ADIWG::Mdtranslator::VERSION
+   spec.authors = ["Stan Smith", "Josh Bradley"]
+   spec.email = ["stansmith@usgs.gov", "joshua_bradley@fws.gov"]
+   spec.summary = %q{The mdtranslator (metadata translator) is a tool for translating metadata in one format to another. The tool is written and maintained by the Alaska Data Integration Working Group (ADIwg).}
+   spec.description = %q{The mdtranslator was written by the Alaska Data Integration Working Group (ADIwg) to assist with creating ISO 19139 metadata records.  Input to the mdtranslator is JSON conforming to the mdJson-schema.  The mdtranslator architecture allows developers to write additional readers for other input formats and/or write additional writers for other output other than ISO 19139.}
+   spec.homepage = "http://www.adiwg.org/mdTranslator"
+   spec.license = "UNLICENSED"
 
-    spec.files = %x(git ls-files).split($/).delete_if{|f| /^test*/.match(f)}
-    spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-    spec.test_files = spec.files.grep(%r{^(tc|test|spec|features)/})
-    spec.require_paths = ["lib"]
+   spec.files = %x(git ls-files).split($/).delete_if {|f| /^test*/.match(f)}
+   spec.executables = spec.files.grep(%r{^bin/}) {|f| File.basename(f)}
+   spec.test_files = spec.files.grep(%r{^(tc|test|spec|features)/})
+   spec.require_paths = ["lib"]
 
-    spec.required_ruby_version = '>= 2.1'
+   spec.required_ruby_version = '>= 2.1'
 
-    spec.add_development_dependency "bundler", "~> 1"
-    spec.add_development_dependency "rake", "~> 10"
-    spec.add_development_dependency "minitest", "~> 5"
+   spec.add_development_dependency "bundler", "~> 1"
+   spec.add_development_dependency "rake", "~> 10"
+   spec.add_development_dependency "minitest", "~> 5"
 
-    spec.add_runtime_dependency "json", "~> 2.0"
-    spec.add_runtime_dependency "builder", "~> 3.2"
-    spec.add_runtime_dependency "thor", "~> 0.19"
-    spec.add_runtime_dependency "uuidtools", "~> 2.1"
-    spec.add_runtime_dependency "json-schema", "~> 2.7"
-    spec.add_runtime_dependency "adiwg-mdjson_schemas", ">= 2.0"
-    spec.add_runtime_dependency "adiwg-mdcodes", "~> 2.1"
-    spec.add_runtime_dependency "jbuilder", "~> 2.5"
-    spec.add_runtime_dependency "rgeo", "~> 0.5"
-    spec.add_runtime_dependency "activesupport", "< 5"
+   spec.add_runtime_dependency "json", "~> 2.0"
+   spec.add_runtime_dependency "builder", "~> 3.2"
+   spec.add_runtime_dependency "thor", "~> 0.19"
+   spec.add_runtime_dependency "uuidtools", "~> 2.1"
+   spec.add_runtime_dependency "json-schema", "~> 2.7"
+   spec.add_runtime_dependency "adiwg-mdjson_schemas", ">= 2.1.1"
+   spec.add_runtime_dependency "adiwg-mdcodes", "~> 2.1"
+   spec.add_runtime_dependency "jbuilder", "~> 2.5"
 
 end

--- a/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
+++ b/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
@@ -2,62 +2,62 @@
 
 # History:
 # version 2
-#   Stan Smith 2017-04-22 removed 'intObj = ' from new object definitions
-#   Stan Smith 2017-02-15 added newResourceType
-#   Stan Smith 2017-02-09 added newMetadataRepository
-#   Stan Smith 2017-01-20 refactored newDataDictionary
-#   Stan Smith 2016-11-10 added computedBbox to newGeographicExtent, newGeometryCollection
-#   Stan Smith 2016-11-10 added computedBbox to newGeometryFeature, newFeatureCollection
-#   Stan Smith 2016-11-02 added newSchema
-#   Stan Smith 2016-10-30 added newAllocation, newFunding
-#   Stan Smith 2016-10-25 added newFeatureCollection
-#   Stan Smith 2016-10-25 added newGeoJson
-#   Stan Smith 2016-10-25 added newGeometryCollection
-#   Stan Smith 2016-10-25 added newGeometryFeature
-#   Stan Smith 2016-10-25 added newGeometryObject
-#   Stan Smith 2016-10-25 added newGeometryProperties
-#   Stan Smith 2016-10-23 renamed newResourceMaint to newMaintenance
-#   Stan Smith 2016-10-21 added newDistribution
-#   Stan Smith 2016-10-21 renamed newDistOrder to newOrderProcess
-#   Stan Smith 2016-10-21 renamed newDigitalTransOption to newTransferOption
-#   Stan Smith 2016-10-20 deleted newDictionaryInfo, move element to newDataDictionary
-#   Stan Smith 2016-10-19 added newSpatialRepresentation
-#   Stan Smith 2016-10-19 added newGeorectifiedInfo
-#   Stan Smith 2016-10-19 added newVectorInfo, newVectorObject
-#   Stan Smith 2016-10-18 deleted newCoverageInfo, newCoverageItem
-#   Stan Smith 2016-10-18 added newAttributeGroup
-#   Stan Smith 2016-10-18 deleted newClassedData, newClassedDataItem
-#   Stan Smith 2016-10-17 added elements to newLineage
-#   Stan Smith 2016-10-17 added elements to newDataSource
-#   Stan Smith 2016-10-16 removed newResolution
-#   Stan Smith 2016-10-16 added newMeasure
-#   Stan Smith 2016-10-16 added newSpatialResolution
-#   Stan Smith 2016-10-15 renamed newDataProcess Step to newProcessStep
-#   Stan Smith 2016-10-15 added newConstraints object
-#   Stan Smith 2016-10-15 added constraint object to newSecurityConstraint
-#   Stan Smith 2016-10-15 added constraint object to newLegalConstraint
-#   Stan Smith 2016-10-15 added newConstraint object
-#   Stan Smith 2016-10-15 added newRelease object
-#   Stan Smith 2016-10-14 added newScope object
-#   Stan Smith 2016-10-14 added newTimeInterval object
-#   Stan Smith 2016-10-13 added newScopeDescription object
-#   Stan Smith 2016-10-13 added attributes to newCitation for mdJson 2.0
-#   Stan Smith 2016-10-13 renamed newResourceId to newIdentifier, dropped identifierType
-#   Stan Smith 2016-10-12 renamed newBrowseGraphic to newGraphic, added graphicConstraint []
-#   Stan Smith 2016-10-12 added newSeries object
-#   Stan Smith 2016-10-12 added newDate object
-#   Stan Smith 2016-10-11 renamed newDataUsage to newResourceUsage
-#   Stan Smith 2016-10-09 add newParty
-#   Stan Smith 2016-10-08 removed dateType from dateTime object
-#   Stan Smith 2016-10-01 made phone service types an array
-#   Stan Smith 2016-10-03 added duration object
+#  Stan Smith 2017-04-22 removed 'intObj = ' from new object definitions
+#  Stan Smith 2017-02-15 added newResourceType
+#  Stan Smith 2017-02-09 added newMetadataRepository
+#  Stan Smith 2017-01-20 refactored newDataDictionary
+#  Stan Smith 2016-11-10 added computedBbox to newGeographicExtent, newGeometryCollection
+#  Stan Smith 2016-11-10 added computedBbox to newGeometryFeature, newFeatureCollection
+#  Stan Smith 2016-11-02 added newSchema
+#  Stan Smith 2016-10-30 added newAllocation, newFunding
+#  Stan Smith 2016-10-25 added newFeatureCollection
+#  Stan Smith 2016-10-25 added newGeoJson
+#  Stan Smith 2016-10-25 added newGeometryCollection
+#  Stan Smith 2016-10-25 added newGeometryFeature
+#  Stan Smith 2016-10-25 added newGeometryObject
+#  Stan Smith 2016-10-25 added newGeometryProperties
+#  Stan Smith 2016-10-23 renamed newResourceMaint to newMaintenance
+#  Stan Smith 2016-10-21 added newDistribution
+#  Stan Smith 2016-10-21 renamed newDistOrder to newOrderProcess
+#  Stan Smith 2016-10-21 renamed newDigitalTransOption to newTransferOption
+#  Stan Smith 2016-10-20 deleted newDictionaryInfo, move element to newDataDictionary
+#  Stan Smith 2016-10-19 added newSpatialRepresentation
+#  Stan Smith 2016-10-19 added newGeorectifiedInfo
+#  Stan Smith 2016-10-19 added newVectorInfo, newVectorObject
+#  Stan Smith 2016-10-18 deleted newCoverageInfo, newCoverageItem
+#  Stan Smith 2016-10-18 added newAttributeGroup
+#  Stan Smith 2016-10-18 deleted newClassedData, newClassedDataItem
+#  Stan Smith 2016-10-17 added elements to newLineage
+#  Stan Smith 2016-10-17 added elements to newDataSource
+#  Stan Smith 2016-10-16 removed newResolution
+#  Stan Smith 2016-10-16 added newMeasure
+#  Stan Smith 2016-10-16 added newSpatialResolution
+#  Stan Smith 2016-10-15 renamed newDataProcess Step to newProcessStep
+#  Stan Smith 2016-10-15 added newConstraints object
+#  Stan Smith 2016-10-15 added constraint object to newSecurityConstraint
+#  Stan Smith 2016-10-15 added constraint object to newLegalConstraint
+#  Stan Smith 2016-10-15 added newConstraint object
+#  Stan Smith 2016-10-15 added newRelease object
+#  Stan Smith 2016-10-14 added newScope object
+#  Stan Smith 2016-10-14 added newTimeInterval object
+#  Stan Smith 2016-10-13 added newScopeDescription object
+#  Stan Smith 2016-10-13 added attributes to newCitation for mdJson 2.0
+#  Stan Smith 2016-10-13 renamed newResourceId to newIdentifier, dropped identifierType
+#  Stan Smith 2016-10-12 renamed newBrowseGraphic to newGraphic, added graphicConstraint []
+#  Stan Smith 2016-10-12 added newSeries object
+#  Stan Smith 2016-10-12 added newDate object
+#  Stan Smith 2016-10-11 renamed newDataUsage to newResourceUsage
+#  Stan Smith 2016-10-09 add newParty
+#  Stan Smith 2016-10-08 removed dateType from dateTime object
+#  Stan Smith 2016-10-01 made phone service types an array
+#  Stan Smith 2016-10-03 added duration object
 
 # version 1
-#   Stan Smith 2015-07-23 added gridInfo, gridDimension for 1.3.0
-#   Stan Smith 2015-07-28 added locale for 1.3.0
-#   Stan Smith 2015-08-19 added coverageInfo, imageInfo, sensorInfo, coverageItem,
-#                     ... classifiedData, and classedDataItem for 1.3.0
-#   Stan Smith 2015-09-18 extended distributionInfo sections for 1.3.0
+#  Stan Smith 2015-07-23 added gridInfo, gridDimension for 1.3.0
+#  Stan Smith 2015-07-28 added locale for 1.3.0
+#  Stan Smith 2015-08-19 added coverageInfo, imageInfo, sensorInfo, coverageItem,
+#             ... classifiedData, and classedDataItem for 1.3.0
+#  Stan Smith 2015-09-18 extended distributionInfo sections for 1.3.0
 
 # version 0
 # 	Stan Smith 2013-08-09 original script
@@ -88,899 +88,899 @@
 # 	Stan Smith 2013-11-20 added data quality
 # 	Stan Smith 2013-11-20 modified citation
 # 	Stan Smith 2013-12-16 added phone book
-#   Stan Smith 2014-04-23 added protocol and doi to online resource
-#   Stan Smith 2014-04-24 added schema to newBase
-#   Stan Smith 2014-04-24 renamed newDataId to newResourceInfo
-#   Stan Smith 2014-04-24 reorganized newMetadata, newResourceInfo
-#   Stan Smith 2014-04-24 added newMetadataInfo
-#   Stan Smith 2014-04-25 modified newCitation for json schema 0.3.0
-#   Stan Smith 2014-04-25 added resource Ids to newCitation
-#   Stan Smith 2014-04-30 reorganized geometry blocks for json schema 0.3.0
-#   Stan Smith 2014-05-02 added associatedResource
-#   Stan Smith 2014-05-02 added additionalDocument
-#   Stan Smith 2014-05-28 modified resourceId & responsibleParty for schema 0.5.0
-#   Stan Smith 2014-08-15 modified citation, onlineResource, resourceId for 0.6.0
-#   Stan Smith 2014-09-03 added spatialReferenceSystems for name, EPSG, and WKT for 0.6.0
-#   Stan Smith 2014-11-06 added resourceType to resourceInfo for 0.9.0
-#   Stan Smith 2014-11-06 removed metadataScope from metadataInfo for 0.9.0
-#   Stan Smith 2014-11-06 added newAdditionalDocumentation
-#   Stan Smith 2014-12-01 added data dictionary
-#   Stan Smith 2015-02-17 add entity and attribute alias
-#   Stan Smith 2015-02-17 added support for multiple data dictionaries
+#  Stan Smith 2014-04-23 added protocol and doi to online resource
+#  Stan Smith 2014-04-24 added schema to newBase
+#  Stan Smith 2014-04-24 renamed newDataId to newResourceInfo
+#  Stan Smith 2014-04-24 reorganized newMetadata, newResourceInfo
+#  Stan Smith 2014-04-24 added newMetadataInfo
+#  Stan Smith 2014-04-25 modified newCitation for json schema 0.3.0
+#  Stan Smith 2014-04-25 added resource Ids to newCitation
+#  Stan Smith 2014-04-30 reorganized geometry blocks for json schema 0.3.0
+#  Stan Smith 2014-05-02 added associatedResource
+#  Stan Smith 2014-05-02 added additionalDocument
+#  Stan Smith 2014-05-28 modified resourceId & responsibleParty for schema 0.5.0
+#  Stan Smith 2014-08-15 modified citation, onlineResource, resourceId for 0.6.0
+#  Stan Smith 2014-09-03 added spatialReferenceSystems for name, EPSG, and WKT for 0.6.0
+#  Stan Smith 2014-11-06 added resourceType to resourceInfo for 0.9.0
+#  Stan Smith 2014-11-06 removed metadataScope from metadataInfo for 0.9.0
+#  Stan Smith 2014-11-06 added newAdditionalDocumentation
+#  Stan Smith 2014-12-01 added data dictionary
+#  Stan Smith 2015-02-17 add entity and attribute alias
+#  Stan Smith 2015-02-17 added support for multiple data dictionaries
 
 class InternalMetadata
 
-    # initialize Boolean - false
-    # initialize scalar - nil
-    # initialize hash - {}
-    # initialize array - []
-
-    def initialize
-    end
-
-    def newBase
-        {
-            schema: {},
-            contacts: [],
-            metadata: {},
-            dataDictionaries: [],
-            metadataRepositories: []
-        }
-    end
-
-    def newSchema
-        {
-            name: nil,
-            version: nil
-        }
-    end
-
-    def newDate
-        {
-            date: nil,
-            dateResolution: nil,
-            dateType: nil,
-            description: nil
-        }
-    end
-
-    def newDateTime
-        {
-            dateTime: nil,
-            dateResolution: nil
-        }
-    end
-
-    def newContact
-        {
-            contactId: nil,
-            isOrganization: false,
-            name: nil,
-            positionName: nil,
-            memberOfOrgs: [],
-            logos: [],
-            phones: [],
-            addresses: [],
-            eMailList: [],
-            onlineResources: [],
-            hoursOfService: [],
-            contactInstructions: nil,
-            contactType: nil
-        }
-    end
-
-    def newPhone
-        {
-            phoneName: nil,
-            phoneNumber: nil,
-            phoneServiceTypes: []
-        }
-    end
-
-    def newAddress
-        {
-            addressTypes: [],
-            description: nil,
-            deliveryPoints: [],
-            city: nil,
-            adminArea: nil,
-            postalCode: nil,
-            country: nil
-        }
-    end
-
-    def newMetadata
-        {
-            metadataInfo: {},
-            resourceInfo: {},
-            lineageInfo: [],
-            distributorInfo: [],
-            associatedResources: [],
-            additionalDocuments: [],
-            funding: []
-        }
-    end
-
-    def newMetadataInfo
-        {
-            metadataIdentifier: {},
-            parentMetadata: {},
-            defaultMetadataLocale: {},
-            otherMetadataLocales: [],
-            metadataContacts: [],
-            metadataDates: [],
-            metadataLinkages: [],
-            metadataMaintenance: {},
-            alternateMetadataReferences: [],
-            metadataStatus: nil,
-            extensions: []
-        }
-    end
-
-    def newResponsibility
-        {
-            roleName: nil,
-            roleExtents: [],
-            parties: []
-        }
-    end
-
-    def newParty
-        {
-            contactId: nil,
-            contactIndex: nil,
-            contactType: nil,
-            organizationMembers: []
-        }
-    end
-
-    def newOnlineResource
-        {
-            olResURI: nil,
-            olResProtocol: nil,
-            olResName: nil,
-            olResDesc: nil,
-            olResFunction: nil
-        }
-    end
-
-    def newResourceInfo
-        {
-            resourceTypes: [],
-            citation: {},
-            abstract: nil,
-            shortAbstract: nil,
-            purpose: nil,
-            credits: [],
-            timePeriod: {},
-            status: [],
-            topicCategories: [],
-            pointOfContacts: [],
-            spatialReferenceSystems: [],
-            spatialRepresentationTypes: [],
-            spatialRepresentations: [],
-            spatialResolutions: [],
-            temporalResolutions: [],
-            extents: [],
-            coverageDescriptions: [],
-            taxonomy: {},
-            graphicOverviews: [],
-            resourceFormats: [],
-            keywords: [],
-            resourceUsages: [],
-            constraints: [],
-            defaultResourceLocale: {},
-            otherResourceLocales: [],
-            resourceMaintenance: [],
-            environmentDescription: nil,
-            supplementalInfo: nil
-        }
-    end
-
-    def newCitation
-        {
-            title: nil,
-            alternateTitles: [],
-            dates: [],
-            edition: nil,
-            responsibleParties: [],
-            presentationForms: [],
-            identifiers: [],
-            series: {},
-            otherDetails: [],
-            onlineResources: [],
-            browseGraphics: []
-        }
-    end
-
-
-    def newIdentifier
-        # handles MD_Identifier (ISO 19115-2 & -1)
-        # handles RS_ Identifier (ISO 19115-2)
-        # handles gmlIdentifier
-        {
-            identifier: nil,
-            namespace: nil,
-            version: nil,
-            description: nil,
-            citation: {}
-        }
-    end
-
-    def newMaintenance
-        {
-            frequency: nil,
-            dates: [],
-            scopes: [],
-            notes: [],
-            contacts: []
-        }
-    end
-
-    def newKeyword
-        {
-            keywords: [],
-            keywordType: nil,
-            thesaurus: {}
-        }
-    end
-
-    def newKeywordObject
-        {
-            keyword: nil,
-            keywordId: nil
-        }
-    end
-
-    def newConstraint
-        {
-            type: nil,
-            useLimitation: [],
-            scope: {},
-            graphic: [],
-            reference: [],
-            releasability: {},
-            responsibleParty: [],
-            legalConstraint: {},
-            securityConstraint: {}
-        }
-    end
-
-    def newLegalConstraint
-        {
-            accessCodes: [],
-            useCodes: [],
-            otherCons: []
-        }
-    end
-
-    def newSecurityConstraint
-        {
-            classCode: nil,
-            userNote: nil,
-            classSystem: nil,
-            handling: nil
-        }
-    end
-
-    def newRelease
-        {
-            addressee: [],
-            statement: nil,
-            disseminationConstraint: []
-        }
-    end
-
-    def newDistribution
-        {
-            description: nil,
-            distributor: []
-        }
-    end
-
-    def newDistributor
-        {
-            contact: {},
-            orderProcess: [],
-            transferOptions: []
-        }
-    end
-
-    def newOrderProcess
-        {
-            fees: nil,
-            plannedAvailability: {},
-            orderingInstructions: nil,
-            turnaround: nil
-        }
-    end
-
-    def newTransferOption
-        {
-            unitsOfDistribution: nil,
-            transferSize: nil,
-            onlineOptions: [],
-            offlineOptions: [],
-            transferFrequency: {},
-            distributionFormats: []
-        }
-    end
-
-    def newMedium
-        {
-            mediumSpecification: {},
-            density: nil,
-            units: nil,
-            numberOfVolumes: nil,
-            mediumFormat: [],
-            note: nil,
-            identifier: {}
-        }
-    end
-
-    def newResourceFormat
-        {
-            formatSpecification: {},
-            amendmentNumber: nil,
-            compressionMethod: nil
-        }
-    end
-
-    def newGraphic
-        {
-            graphicName: nil,
-            graphicDescription: nil,
-            graphicType: nil,
-            graphicConstraints: [],
-            graphicURI: []
-        }
-    end
-
-    def newSpatialReferenceSystem
-        {
-            systemType: nil,
-            systemIdentifier: {}
-        }
-    end
-
-    def newSpatialResolution
-        {
-            scaleFactor: nil,
-            measure: {},
-            levelOfDetail: nil
-        }
-    end
-
-    def newMeasure
-        {
-            type: nil,
-            value: nil,
-            unitOfMeasure: nil
-        }
-    end
-
-    def newExtent
-        {
-            description: nil,
-            geographicExtents: [],
-            temporalExtents: [],
-            verticalExtents: []
-        }
-    end
-
-    def newGeographicExtent
-        {
-            containsData: true,
-            identifier: {},
-            boundingBox: {},
-            geographicElements: [],
-            nativeGeoJson: [],
-            computedBbox: {}
-        }
-    end
-
-    def newBoundingBox
-        {
-            westLongitude: nil,
-            eastLongitude: nil,
-            southLatitude: nil,
-            northLatitude: nil
-        }
-    end
-
-    def newGeometryObject
-        {
-            type: nil,
-            coordinates: [],
-            nativeGeoJson: {}
-        }
-    end
-
-    def newGeometryCollection
-        {
-            type: nil,
-            bbox: [],
-            geometryObjects: [],
-            computedBbox: [],
-            nativeGeoJson: {}
-        }
-    end
-
-    def newGeometryProperties
-        {
-            featureNames: [],
-            description: nil,
-            identifiers: [],
-            featureScope: nil,
-            acquisitionMethod: nil
-        }
-    end
-
-    def newGeometryFeature
-        {
-            type: nil,
-            id: nil,
-            bbox: [],
-            geometryObject: {},
-            properties: {},
-            computedBbox: [],
-            nativeGeoJson: {}
-        }
-    end
-
-    def newFeatureCollection
-        {
-            type: nil,
-            bbox: [],
-            features: [],
-            computedBbox: [],
-            nativeGeoJson: {}
-        }
-    end
-
-    def newTemporalExtent
-        {
-            timeInstant: {},
-            timePeriod: {}
-        }
-    end
-
-    def newTimeInstant
-        {
-            timeId: nil,
-            description: nil,
-            identifier: {},
-            instantNames: [],
-            timeInstant: {}
-        }
-    end
-
-    def newTimePeriod
-        {
-            timeId: nil,
-            description: nil,
-            identifier: {},
-            periodNames: [],
-            startDateTime: {},
-            endDateTime: {},
-            timeInterval: {},
-            duration: {}
-        }
-    end
-
-    def newDuration
-        {
-            years: nil,
-            months: nil,
-            days: nil,
-            hours: nil,
-            minutes: nil,
-            seconds: nil
-        }
-    end
-
-    def newTimeInterval
-        {
-            interval: nil,
-            units: nil
-        }
-    end
-
-    def newVerticalExtent
-        {
-            description: nil,
-            minValue: nil,
-            maxValue: nil,
-            crsId: {}
-        }
-    end
-
-    def newResourceUsage
-        {
-            specificUsage: nil,
-            temporalExtents: [],
-            userLimitation: nil,
-            limitationResponses: [],
-            identifiedIssue: {},
-            additionalDocumentation: [],
-            userContacts: []
-        }
-    end
-
-    def newTaxonomy
-        {
-            taxonSystem: [],
-            generalScope: nil,
-            idReferences: [],
-            observers: [],
-            idProcedure: nil,
-            idCompleteness: nil,
-            vouchers: [],
-            taxonClass: {}
-        }
-    end
-
-    def newTaxonSystem
-        {
-            citation: {},
-            modifications: nil
-        }
-    end
-
-    def newTaxonVoucher
-        {
-            specimen: nil,
-            repository: {}
-        }
-    end
-
-    def newTaxonClass
-        {
-            taxonId: nil,
-            taxonRank: nil,
-            taxonValue: nil,
-            commonNames: [],
-            subClasses: []
-        }
-    end
-
-    def newLineage
-        {
-            statement: nil,
-            resourceScope: {},
-            lineageCitation: [],
-            dataSources: [],
-            processSteps: []
-        }
-    end
-
-    def newProcessStep
-        {
-            stepId: nil,
-            description: nil,
-            rationale: nil,
-            timePeriod: {},
-            processors: [],
-            references: [],
-            scope: {}
-        }
-    end
-
-    def newDataSource
-        {
-            description: nil,
-            sourceCitation: {},
-            metadataCitation: [],
-            spatialResolution: {},
-            referenceSystem: {},
-            sourceSteps: [],
-            scope: {}
-        }
-    end
-
-    def newMetadataExtension
-        {
-            onLineResource: {},
-            name: nil,
-            shortName: nil,
-            definition: nil,
-            obligation: nil,
-            dataType: nil,
-            maxOccurrence: nil,
-            parentEntities: [],
-            rule: nil,
-            rationales: [],
-            sourceOrganization: nil,
-            sourceURI: nil,
-            sourceRole: nil
-        }
-    end
-
-    def newAssociatedResource
-        {
-            resourceTypes: [],
-            associationType: nil,
-            initiativeType: nil,
-            resourceCitation: {},
-            metadataCitation: {}
-        }
-    end
-
-    def newAdditionalDocumentation
-        {
-            resourceTypes: [],
-            citation: []
-        }
-    end
-
-    def newDataDictionary
-        {
-            citation: {},
-            subjects: [],
-            recommendedUses: [],
-            locales: [],
-            responsibleParty: {},
-            dictionaryFormat: nil,
-            includedWithDataset: false,
-            domains: [],
-            entities: []
-        }
-    end
-
-    def newDictionaryDomain
-        {
-            domainId: nil,
-            domainName: nil,
-            domainCode: nil,
-            domainDescription: nil,
-            domainItems: []
-        }
-    end
-
-    def newDomainItem
-        {
-            itemName: nil,
-            itemValue: nil,
-            itemDefinition: nil
-        }
-    end
-
-    def newEntity
-        {
-            entityId: nil,
-            entityName: nil,
-            entityCode: nil,
-            entityAlias: [],
-            entityDefinition: nil,
-            primaryKey: [],
-            indexes: [],
-            attributes: [],
-            foreignKeys: []
-        }
-    end
-
-    def newEntityIndex
-        {
-            indexCode: nil,
-            duplicate: false,
-            attributeNames: []
-        }
-    end
-
-    def newEntityAttribute
-        {
-            attributeName: nil,
-            attributeCode: nil,
-            attributeAlias: [],
-            attributeDefinition: nil,
-            dataType: nil,
-            allowNull: false,
-            allowMany: false,
-            unitOfMeasure: nil,
-            domainId: nil,
-            minValue: nil,
-            maxValue: nil
-        }
-    end
-
-    def newEntityForeignKey
-        {
-            fkLocalAttributes: [],
-            fkReferencedEntity: nil,
-            fkReferencedAttributes: []
-        }
-    end
-
-    def newSpatialRepresentation
-        {
-            gridRepresentation: {},
-            vectorRepresentation: {},
-            georectifiedRepresentation: {},
-            georeferenceableRepresentation: {}
-        }
-    end
-
-    def newGridInfo
-        {
-            numberOfDimensions: nil,
-            dimension: [],
-            cellGeometry: nil,
-            transformationParameterAvailable: false
-        }
-    end
-
-    def newDimension
-        {
-            dimensionType: nil,
-            dimensionTitle: nil,
-            dimensionDescription: nil,
-            dimensionSize: nil,
-            resolution: {}
-        }
-    end
-
-    def newVectorInfo
-        {
-            topologyLevel: nil,
-            vectorObject: []
-        }
-    end
-
-    def newVectorObject
-        {
-            objectType: nil,
-            objectCount: nil
-        }
-    end
-
-    def newGeorectifiedInfo
-        {
-            gridRepresentation: {},
-            checkPointAvailable: false,
-            checkPointDescription: nil,
-            cornerPoints: [],
-            centerPoint: [],
-            pointInPixel: nil,
-            transformationDimensionDescription: nil,
-            transformationDimensionMapping: nil
-        }
-    end
-
-    def newGeoreferenceableInfo
-        {
-            gridRepresentation: {},
-            controlPointAvailable: false,
-            orientationParameterAvailable: false,
-            orientationParameterDescription: nil,
-            georeferencedParameter: nil,
-            parameterCitation: []
-        }
-    end
-
-    def newCoverageDescription
-        {
-            coverageName: nil,
-            coverageDescription: nil,
-            processingLevelCode: {},
-            attributeGroups: [],
-            imageDescription: {}
-        }
-    end
-
-    def newAttributeGroup
-        {
-            attributeContentTypes: [],
-            attributes: []
-        }
-    end
-
-    def newAttribute
-        {
-            sequenceIdentifier: nil,
-            sequenceIdentifierType: nil,
-            attributeDescription: nil,
-            attributeIdentifiers: [],
-            minValue: nil,
-            maxValue: nil,
-            units: nil,
-            scaleFactor: nil,
-            offset: nil,
-            meanValue: nil,
-            numberOfValues: nil,
-            standardDeviation: nil,
-            bitsPerValue: nil,
-            boundMin: nil,
-            boundMax: nil,
-            boundUnits: nil,
-            peakResponse: nil,
-            toneGradations: nil,
-            bandBoundaryDefinition: nil,
-            nominalSpatialResolution: nil,
-            transferFunctionType: nil,
-            transmittedPolarization: nil,
-            detectedPolarization: nil
-        }
-    end
-
-    def newImageDescription
-        {
-            illuminationElevationAngle: nil,
-            illuminationAzimuthAngle: nil,
-            imagingCondition: nil,
-            imageQualityCode: {},
-            cloudCoverPercent: nil,
-            compressionQuantity: nil,
-            triangulationIndicator: false,
-            radiometricCalibrationAvailable: false,
-            cameraCalibrationAvailable: false,
-            filmDistortionAvailable: false,
-            lensDistortionAvailable: false
-        }
-    end
-
-    def newLocale
-        {
-            languageCode: nil,
-            countryCode: nil,
-            characterEncoding: nil
-        }
-    end
-
-    def newSeries
-        {
-            seriesName: nil,
-            seriesIssue: nil,
-            issuePage: nil
-        }
-    end
-
-    def newScope
-        {
-            scopeCode: nil,
-            scopeDescriptions: [],
-            extents: []
-        }
-    end
-
-    def newScopeDescription
-        {
-            dataset: nil,
-            attributes: nil,
-            features: nil,
-            other: nil
-        }
-    end
-
-    def newAllocation
-        {
-            amount: nil,
-            currency: nil,
-            sourceId: nil,
-            recipientId: nil,
-            matching: false,
-            comment: nil
-        }
-    end
-
-    def newFunding
-        {
-            allocations: [],
-            timePeriod: {}
-        }
-    end
-
-    def newMetadataRepository
-        {
-            repository: nil,
-            metadataStandard: nil
-        }
-    end
-
-    def newResourceType
-        {
-            type: nil,
-            name: nil
-        }
-    end
+   # initialize Boolean - false
+   # initialize scalar - nil
+   # initialize hash - {}
+   # initialize array - []
+
+   def initialize
+   end
+
+   def newBase
+      {
+         schema: {},
+         contacts: [],
+         metadata: {},
+         dataDictionaries: [],
+         metadataRepositories: []
+      }
+   end
+
+   def newSchema
+      {
+         name: nil,
+         version: nil
+      }
+   end
+
+   def newDate
+      {
+         date: nil,
+         dateResolution: nil,
+         dateType: nil,
+         description: nil
+      }
+   end
+
+   def newDateTime
+      {
+         dateTime: nil,
+         dateResolution: nil
+      }
+   end
+
+   def newContact
+      {
+         contactId: nil,
+         isOrganization: false,
+         name: nil,
+         positionName: nil,
+         memberOfOrgs: [],
+         logos: [],
+         phones: [],
+         addresses: [],
+         eMailList: [],
+         onlineResources: [],
+         hoursOfService: [],
+         contactInstructions: nil,
+         contactType: nil
+      }
+   end
+
+   def newPhone
+      {
+         phoneName: nil,
+         phoneNumber: nil,
+         phoneServiceTypes: []
+      }
+   end
+
+   def newAddress
+      {
+         addressTypes: [],
+         description: nil,
+         deliveryPoints: [],
+         city: nil,
+         adminArea: nil,
+         postalCode: nil,
+         country: nil
+      }
+   end
+
+   def newMetadata
+      {
+         metadataInfo: {},
+         resourceInfo: {},
+         lineageInfo: [],
+         distributorInfo: [],
+         associatedResources: [],
+         additionalDocuments: [],
+         funding: []
+      }
+   end
+
+   def newMetadataInfo
+      {
+         metadataIdentifier: {},
+         parentMetadata: {},
+         defaultMetadataLocale: {},
+         otherMetadataLocales: [],
+         metadataContacts: [],
+         metadataDates: [],
+         metadataLinkages: [],
+         metadataMaintenance: {},
+         alternateMetadataReferences: [],
+         metadataStatus: nil,
+         extensions: []
+      }
+   end
+
+   def newResponsibility
+      {
+         roleName: nil,
+         roleExtents: [],
+         parties: []
+      }
+   end
+
+   def newParty
+      {
+         contactId: nil,
+         contactIndex: nil,
+         contactType: nil,
+         organizationMembers: []
+      }
+   end
+
+   def newOnlineResource
+      {
+         olResURI: nil,
+         olResProtocol: nil,
+         olResName: nil,
+         olResDesc: nil,
+         olResFunction: nil
+      }
+   end
+
+   def newResourceInfo
+      {
+         resourceTypes: [],
+         citation: {},
+         abstract: nil,
+         shortAbstract: nil,
+         purpose: nil,
+         credits: [],
+         timePeriod: {},
+         status: [],
+         topicCategories: [],
+         pointOfContacts: [],
+         spatialReferenceSystems: [],
+         spatialRepresentationTypes: [],
+         spatialRepresentations: [],
+         spatialResolutions: [],
+         temporalResolutions: [],
+         extents: [],
+         coverageDescriptions: [],
+         taxonomy: {},
+         graphicOverviews: [],
+         resourceFormats: [],
+         keywords: [],
+         resourceUsages: [],
+         constraints: [],
+         defaultResourceLocale: {},
+         otherResourceLocales: [],
+         resourceMaintenance: [],
+         environmentDescription: nil,
+         supplementalInfo: nil
+      }
+   end
+
+   def newCitation
+      {
+         title: nil,
+         alternateTitles: [],
+         dates: [],
+         edition: nil,
+         responsibleParties: [],
+         presentationForms: [],
+         identifiers: [],
+         series: {},
+         otherDetails: [],
+         onlineResources: [],
+         browseGraphics: []
+      }
+   end
+
+
+   def newIdentifier
+      # handles MD_Identifier (ISO 19115-2 & -1)
+      # handles RS_ Identifier (ISO 19115-2)
+      # handles gmlIdentifier
+      {
+         identifier: nil,
+         namespace: nil,
+         version: nil,
+         description: nil,
+         citation: {}
+      }
+   end
+
+   def newMaintenance
+      {
+         frequency: nil,
+         dates: [],
+         scopes: [],
+         notes: [],
+         contacts: []
+      }
+   end
+
+   def newKeyword
+      {
+         keywords: [],
+         keywordType: nil,
+         thesaurus: {}
+      }
+   end
+
+   def newKeywordObject
+      {
+         keyword: nil,
+         keywordId: nil
+      }
+   end
+
+   def newConstraint
+      {
+         type: nil,
+         useLimitation: [],
+         scope: {},
+         graphic: [],
+         reference: [],
+         releasability: {},
+         responsibleParty: [],
+         legalConstraint: {},
+         securityConstraint: {}
+      }
+   end
+
+   def newLegalConstraint
+      {
+         accessCodes: [],
+         useCodes: [],
+         otherCons: []
+      }
+   end
+
+   def newSecurityConstraint
+      {
+         classCode: nil,
+         userNote: nil,
+         classSystem: nil,
+         handling: nil
+      }
+   end
+
+   def newRelease
+      {
+         addressee: [],
+         statement: nil,
+         disseminationConstraint: []
+      }
+   end
+
+   def newDistribution
+      {
+         description: nil,
+         distributor: []
+      }
+   end
+
+   def newDistributor
+      {
+         contact: {},
+         orderProcess: [],
+         transferOptions: []
+      }
+   end
+
+   def newOrderProcess
+      {
+         fees: nil,
+         plannedAvailability: {},
+         orderingInstructions: nil,
+         turnaround: nil
+      }
+   end
+
+   def newTransferOption
+      {
+         unitsOfDistribution: nil,
+         transferSize: nil,
+         onlineOptions: [],
+         offlineOptions: [],
+         transferFrequency: {},
+         distributionFormats: []
+      }
+   end
+
+   def newMedium
+      {
+         mediumSpecification: {},
+         density: nil,
+         units: nil,
+         numberOfVolumes: nil,
+         mediumFormat: [],
+         note: nil,
+         identifier: {}
+      }
+   end
+
+   def newResourceFormat
+      {
+         formatSpecification: {},
+         amendmentNumber: nil,
+         compressionMethod: nil
+      }
+   end
+
+   def newGraphic
+      {
+         graphicName: nil,
+         graphicDescription: nil,
+         graphicType: nil,
+         graphicConstraints: [],
+         graphicURI: []
+      }
+   end
+
+   def newSpatialReferenceSystem
+      {
+         systemType: nil,
+         systemIdentifier: {}
+      }
+   end
+
+   def newSpatialResolution
+      {
+         scaleFactor: nil,
+         measure: {},
+         levelOfDetail: nil
+      }
+   end
+
+   def newMeasure
+      {
+         type: nil,
+         value: nil,
+         unitOfMeasure: nil
+      }
+   end
+
+   def newExtent
+      {
+         description: nil,
+         geographicExtents: [],
+         temporalExtents: [],
+         verticalExtents: []
+      }
+   end
+
+   def newGeographicExtent
+      {
+         containsData: true,
+         identifier: {},
+         boundingBox: {},
+         geographicElements: [],
+         nativeGeoJson: [],
+         computedBbox: {}
+      }
+   end
+
+   def newBoundingBox
+      {
+         westLongitude: nil,
+         eastLongitude: nil,
+         southLatitude: nil,
+         northLatitude: nil
+      }
+   end
+
+   def newGeometryObject
+      {
+         type: nil,
+         coordinates: [],
+         nativeGeoJson: {}
+      }
+   end
+
+   def newGeometryCollection
+      {
+         type: nil,
+         bbox: [],
+         geometryObjects: [],
+         computedBbox: [],
+         nativeGeoJson: {}
+      }
+   end
+
+   def newGeometryProperties
+      {
+         featureNames: [],
+         description: nil,
+         identifiers: [],
+         featureScope: nil,
+         acquisitionMethod: nil
+      }
+   end
+
+   def newGeometryFeature
+      {
+         type: nil,
+         id: nil,
+         bbox: [],
+         geometryObject: {},
+         properties: {},
+         computedBbox: [],
+         nativeGeoJson: {}
+      }
+   end
+
+   def newFeatureCollection
+      {
+         type: nil,
+         bbox: [],
+         features: [],
+         computedBbox: [],
+         nativeGeoJson: {}
+      }
+   end
+
+   def newTemporalExtent
+      {
+         timeInstant: {},
+         timePeriod: {}
+      }
+   end
+
+   def newTimeInstant
+      {
+         timeId: nil,
+         description: nil,
+         identifier: {},
+         instantNames: [],
+         timeInstant: {}
+      }
+   end
+
+   def newTimePeriod
+      {
+         timeId: nil,
+         description: nil,
+         identifier: {},
+         periodNames: [],
+         startDateTime: {},
+         endDateTime: {},
+         timeInterval: {},
+         duration: {}
+      }
+   end
+
+   def newDuration
+      {
+         years: nil,
+         months: nil,
+         days: nil,
+         hours: nil,
+         minutes: nil,
+         seconds: nil
+      }
+   end
+
+   def newTimeInterval
+      {
+         interval: nil,
+         units: nil
+      }
+   end
+
+   def newVerticalExtent
+      {
+         description: nil,
+         minValue: nil,
+         maxValue: nil,
+         crsId: {}
+      }
+   end
+
+   def newResourceUsage
+      {
+         specificUsage: nil,
+         temporalExtents: [],
+         userLimitation: nil,
+         limitationResponses: [],
+         identifiedIssue: {},
+         additionalDocumentation: [],
+         userContacts: []
+      }
+   end
+
+   def newTaxonomy
+      {
+         taxonSystem: [],
+         generalScope: nil,
+         idReferences: [],
+         observers: [],
+         idProcedure: nil,
+         idCompleteness: nil,
+         vouchers: [],
+         taxonClass: {}
+      }
+   end
+
+   def newTaxonSystem
+      {
+         citation: {},
+         modifications: nil
+      }
+   end
+
+   def newTaxonVoucher
+      {
+         specimen: nil,
+         repository: {}
+      }
+   end
+
+   def newTaxonClass
+      {
+         taxonId: nil,
+         taxonRank: nil,
+         taxonValue: nil,
+         commonNames: [],
+         subClasses: []
+      }
+   end
+
+   def newLineage
+      {
+         statement: nil,
+         resourceScope: {},
+         lineageCitation: [],
+         dataSources: [],
+         processSteps: []
+      }
+   end
+
+   def newProcessStep
+      {
+         stepId: nil,
+         description: nil,
+         rationale: nil,
+         timePeriod: {},
+         processors: [],
+         references: [],
+         scope: {}
+      }
+   end
+
+   def newDataSource
+      {
+         description: nil,
+         sourceCitation: {},
+         metadataCitation: [],
+         spatialResolution: {},
+         referenceSystem: {},
+         sourceSteps: [],
+         scope: {}
+      }
+   end
+
+   def newMetadataExtension
+      {
+         onLineResource: {},
+         name: nil,
+         shortName: nil,
+         definition: nil,
+         obligation: nil,
+         dataType: nil,
+         maxOccurrence: nil,
+         parentEntities: [],
+         rule: nil,
+         rationales: [],
+         sourceOrganization: nil,
+         sourceURI: nil,
+         sourceRole: nil
+      }
+   end
+
+   def newAssociatedResource
+      {
+         resourceTypes: [],
+         associationType: nil,
+         initiativeType: nil,
+         resourceCitation: {},
+         metadataCitation: {}
+      }
+   end
+
+   def newAdditionalDocumentation
+      {
+         resourceTypes: [],
+         citation: []
+      }
+   end
+
+   def newDataDictionary
+      {
+         citation: {},
+         subjects: [],
+         recommendedUses: [],
+         locales: [],
+         responsibleParty: {},
+         dictionaryFormat: nil,
+         includedWithDataset: false,
+         domains: [],
+         entities: []
+      }
+   end
+
+   def newDictionaryDomain
+      {
+         domainId: nil,
+         domainName: nil,
+         domainCode: nil,
+         domainDescription: nil,
+         domainItems: []
+      }
+   end
+
+   def newDomainItem
+      {
+         itemName: nil,
+         itemValue: nil,
+         itemDefinition: nil
+      }
+   end
+
+   def newEntity
+      {
+         entityId: nil,
+         entityName: nil,
+         entityCode: nil,
+         entityAlias: [],
+         entityDefinition: nil,
+         primaryKey: [],
+         indexes: [],
+         attributes: [],
+         foreignKeys: []
+      }
+   end
+
+   def newEntityIndex
+      {
+         indexCode: nil,
+         duplicate: false,
+         attributeNames: []
+      }
+   end
+
+   def newEntityAttribute
+      {
+         attributeName: nil,
+         attributeCode: nil,
+         attributeAlias: [],
+         attributeDefinition: nil,
+         dataType: nil,
+         allowNull: false,
+         allowMany: false,
+         unitOfMeasure: nil,
+         domainId: nil,
+         minValue: nil,
+         maxValue: nil
+      }
+   end
+
+   def newEntityForeignKey
+      {
+         fkLocalAttributes: [],
+         fkReferencedEntity: nil,
+         fkReferencedAttributes: []
+      }
+   end
+
+   def newSpatialRepresentation
+      {
+         gridRepresentation: {},
+         vectorRepresentation: {},
+         georectifiedRepresentation: {},
+         georeferenceableRepresentation: {}
+      }
+   end
+
+   def newGridInfo
+      {
+         numberOfDimensions: nil,
+         dimension: [],
+         cellGeometry: nil,
+         transformationParameterAvailable: false
+      }
+   end
+
+   def newDimension
+      {
+         dimensionType: nil,
+         dimensionTitle: nil,
+         dimensionDescription: nil,
+         dimensionSize: nil,
+         resolution: {}
+      }
+   end
+
+   def newVectorInfo
+      {
+         topologyLevel: nil,
+         vectorObject: []
+      }
+   end
+
+   def newVectorObject
+      {
+         objectType: nil,
+         objectCount: nil
+      }
+   end
+
+   def newGeorectifiedInfo
+      {
+         gridRepresentation: {},
+         checkPointAvailable: false,
+         checkPointDescription: nil,
+         cornerPoints: [],
+         centerPoint: [],
+         pointInPixel: nil,
+         transformationDimensionDescription: nil,
+         transformationDimensionMapping: nil
+      }
+   end
+
+   def newGeoreferenceableInfo
+      {
+         gridRepresentation: {},
+         controlPointAvailable: false,
+         orientationParameterAvailable: false,
+         orientationParameterDescription: nil,
+         georeferencedParameter: nil,
+         parameterCitation: []
+      }
+   end
+
+   def newCoverageDescription
+      {
+         coverageName: nil,
+         coverageDescription: nil,
+         processingLevelCode: {},
+         attributeGroups: [],
+         imageDescription: {}
+      }
+   end
+
+   def newAttributeGroup
+      {
+         attributeContentTypes: [],
+         attributes: []
+      }
+   end
+
+   def newAttribute
+      {
+         sequenceIdentifier: nil,
+         sequenceIdentifierType: nil,
+         attributeDescription: nil,
+         attributeIdentifiers: [],
+         minValue: nil,
+         maxValue: nil,
+         units: nil,
+         scaleFactor: nil,
+         offset: nil,
+         meanValue: nil,
+         numberOfValues: nil,
+         standardDeviation: nil,
+         bitsPerValue: nil,
+         boundMin: nil,
+         boundMax: nil,
+         boundUnits: nil,
+         peakResponse: nil,
+         toneGradations: nil,
+         bandBoundaryDefinition: nil,
+         nominalSpatialResolution: nil,
+         transferFunctionType: nil,
+         transmittedPolarization: nil,
+         detectedPolarization: nil
+      }
+   end
+
+   def newImageDescription
+      {
+         illuminationElevationAngle: nil,
+         illuminationAzimuthAngle: nil,
+         imagingCondition: nil,
+         imageQualityCode: {},
+         cloudCoverPercent: nil,
+         compressionQuantity: nil,
+         triangulationIndicator: false,
+         radiometricCalibrationAvailable: false,
+         cameraCalibrationAvailable: false,
+         filmDistortionAvailable: false,
+         lensDistortionAvailable: false
+      }
+   end
+
+   def newLocale
+      {
+         languageCode: nil,
+         countryCode: nil,
+         characterEncoding: nil
+      }
+   end
+
+   def newSeries
+      {
+         seriesName: nil,
+         seriesIssue: nil,
+         issuePage: nil
+      }
+   end
+
+   def newScope
+      {
+         scopeCode: nil,
+         scopeDescriptions: [],
+         extents: []
+      }
+   end
+
+   def newScopeDescription
+      {
+         dataset: nil,
+         attributes: nil,
+         features: nil,
+         other: nil
+      }
+   end
+
+   def newAllocation
+      {
+         amount: nil,
+         currency: nil,
+         sourceId: nil,
+         recipientId: nil,
+         matching: false,
+         comment: nil
+      }
+   end
+
+   def newFunding
+      {
+         allocations: [],
+         timePeriod: {}
+      }
+   end
+
+   def newMetadataRepository
+      {
+         repository: nil,
+         metadataStandard: nil
+      }
+   end
+
+   def newResourceType
+      {
+         type: nil,
+         name: nil
+      }
+   end
 
 end

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_keyword.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_keyword.rb
@@ -2,14 +2,14 @@
 # Reader - ADIwg JSON to internal data structure
 
 # History:
-#   Stan Smith 2016-10-23 refactored for mdJson 2.0
-#   Stan Smith 2015-08-24 added return if input hash is empty
-#   Stan Smith 2015-07-14 refactored to remove global namespace constants
-#   Stan Smith 2015-06-22 replace global ($response) with passed in object (responseObj)
-#   Stan Smith 2014-12-15 refactored to handle namespacing readers and writers
-#   Stan Smith 2014-08-21 removed extra level of encapsulation "citation" under "thesaurus"
-#   Stan Smith 2014-08-21 removed thesaurus link; replaced by onlineResource to citation
-#   Stan Smith 2014-07-03 resolve require statements using Mdtranslator.reader_module
+#  Stan Smith 2016-10-23 refactored for mdJson 2.0
+#  Stan Smith 2015-08-24 added return if input hash is empty
+#  Stan Smith 2015-07-14 refactored to remove global namespace constants
+#  Stan Smith 2015-06-22 replace global ($response) with passed in object (responseObj)
+#  Stan Smith 2014-12-15 refactored to handle namespacing readers and writers
+#  Stan Smith 2014-08-21 removed extra level of encapsulation "citation" under "thesaurus"
+#  Stan Smith 2014-08-21 removed thesaurus link; replaced by onlineResource to citation
+#  Stan Smith 2014-07-03 resolve require statements using Mdtranslator.reader_module
 # 	Stan Smith 2013-11-27 modified to process single keyword collection
 # 	Stan Smith 2013-09-18 original script
 
@@ -17,67 +17,80 @@ require_relative 'module_citation'
 require_relative 'module_keywordObject'
 
 module ADIWG
-    module Mdtranslator
-        module Readers
-            module MdJson
+   module Mdtranslator
+      module Readers
+         module MdJson
 
-                module Keyword
+            module Keyword
 
-                    def self.unpack(hKeyword, responseObj)
+               def self.unpack(hKeyword, responseObj)
 
-                        # return nil object if input is empty
-                        if hKeyword.empty?
-                            responseObj[:readerExecutionMessages] << 'Keyword is empty'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
+                  # return nil object if input is empty
+                  if hKeyword.empty?
+                     responseObj[:readerExecutionMessages] << 'Keyword is empty'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
+
+                  # instance classes needed in script
+                  intMetadataClass = InternalMetadata.new
+                  intKeyword = intMetadataClass.newKeyword
+
+                  # keyword - keyword [] (required)
+                  if hKeyword.has_key?('keyword')
+                     hKeyword['keyword'].each do |hItem|
+                        unless hItem.empty?
+                           hReturn = KeywordObject.unpack(hItem, responseObj)
+                           unless hReturn.nil?
+                              intKeyword[:keywords] << hReturn
+                           end
                         end
+                     end
+                  end
+                  if intKeyword[:keywords].empty?
+                     responseObj[:readerExecutionMessages] << 'Keyword is missing keywords'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # instance classes needed in script
-                        intMetadataClass = InternalMetadata.new
-                        intKeyword = intMetadataClass.newKeyword
+                  # keyword - keyType
+                  if hKeyword.has_key?('keywordType')
+                     if hKeyword['keywordType'] != ''
+                        intKeyword[:keywordType] = hKeyword['keywordType']
+                     end
+                  end
 
-                        # keyword - keyword [] (required)
-                        if hKeyword.has_key?('keyword')
-                            hKeyword['keyword'].each do |hItem|
-                                unless hItem.empty?
-                                    hReturn = KeywordObject.unpack(hItem, responseObj)
-                                    unless hReturn.nil?
-                                        intKeyword[:keywords] << hReturn
-                                    end
-                                end
-                            end
+                  # keyword - thesaurus {citation}
+                  if hKeyword.has_key?('thesaurus')
+                     hObject = hKeyword['thesaurus']
+                     unless hObject.empty?
+                        hReturn = Citation.unpack(hObject, responseObj)
+                        unless hReturn.nil?
+                           intKeyword[:thesaurus] = hReturn
                         end
-                        if intKeyword[:keywords].empty?
-                            responseObj[:readerExecutionMessages] << 'Keyword is missing keywords'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
+                     end
+                  end
+
+                  # if keywordType is 'isoTopicCategory'
+                  # resourceInfo.topicCategory [] << keyword
+                  topicArray = []
+                  if hKeyword.has_key?('keywordType')
+                     if hKeyword['keywordType'] == 'isoTopicCategory'
+                        hKeyword['keyword'].each do |hItem|
+                           unless hItem.empty?
+                              topicArray << hItem['keyword']
+                           end
                         end
+                     end
+                  end
 
-                        # keyword - keyType
-                        if hKeyword.has_key?('keywordType')
-                            if hKeyword['keywordType'] != ''
-                                intKeyword[:keywordType] = hKeyword['keywordType']
-                            end
-                        end
+                  return intKeyword, topicArray
 
-                        # keyword - thesaurus {citation}
-                        if hKeyword.has_key?('thesaurus')
-                            hObject = hKeyword['thesaurus']
-                            unless hObject.empty?
-                                hReturn = Citation.unpack(hObject, responseObj)
-                                unless hReturn.nil?
-                                    intKeyword[:thesaurus] = hReturn
-                                end
-                            end
-                        end
-
-                        return intKeyword
-
-                    end
-
-                end
+               end
 
             end
-        end
-    end
+
+         end
+      end
+   end
 end

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_resourceInfo.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_resourceInfo.rb
@@ -2,7 +2,9 @@
 # Reader - ADIwg JSON to internal data structure
 
 # History:
-#   Stan Smith 2016-11-01 original script
+#  Stan Smith 2017-05-16 deprecated topic category
+#                    ... topic category is now handled as keyword list
+#  Stan Smith 2016-11-01 original script
 
 require_relative 'module_resourceType'
 require_relative 'module_citation'
@@ -24,341 +26,341 @@ require_relative 'module_locale'
 require_relative 'module_maintenance'
 
 module ADIWG
-    module Mdtranslator
-        module Readers
-            module MdJson
+   module Mdtranslator
+      module Readers
+         module MdJson
 
-                module ResourceInfo
+            module ResourceInfo
 
-                    def self.unpack(hResInfo, responseObj)
+               def self.unpack(hResInfo, responseObj)
 
-                        # return nil object if input is empty
-                        if hResInfo.empty?
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo object is empty'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
-                        end
+                  # return nil object if input is empty
+                  if hResInfo.empty?
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo object is empty'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # instance classes needed in script
-                        intMetadataClass = InternalMetadata.new
-                        intResInfo = intMetadataClass.newResourceInfo
+                  # instance classes needed in script
+                  intMetadataClass = InternalMetadata.new
+                  intResInfo = intMetadataClass.newResourceInfo
 
-                        # resource information - resource type [] (required) {resourceType}
-                        if hResInfo.has_key?('resourceType')
-                            hResInfo['resourceType'].each do |item|
-                                unless item.empty?
-                                    hReturn = ResourceType.unpack(item, responseObj)
-                                    unless hReturn.nil?
-                                        intResInfo[:resourceTypes] << hReturn
-                                    end
-                                end
-                            end
+                  # resource information - resource type [] (required) {resourceType}
+                  if hResInfo.has_key?('resourceType')
+                     hResInfo['resourceType'].each do |item|
+                        unless item.empty?
+                           hReturn = ResourceType.unpack(item, responseObj)
+                           unless hReturn.nil?
+                              intResInfo[:resourceTypes] << hReturn
+                           end
                         end
-                        if intResInfo[:resourceTypes].empty?
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo is missing resourceType'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
-                        end
+                     end
+                  end
+                  if intResInfo[:resourceTypes].empty?
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo is missing resourceType'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # resource information - citation {citation} (required)
-                        if hResInfo.has_key?('citation')
-                            hObject = hResInfo['citation']
-                            unless hObject.empty?
-                                hReturn = Citation.unpack(hObject, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:citation] = hReturn
-                                end
-                            end
+                  # resource information - citation {citation} (required)
+                  if hResInfo.has_key?('citation')
+                     hObject = hResInfo['citation']
+                     unless hObject.empty?
+                        hReturn = Citation.unpack(hObject, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:citation] = hReturn
                         end
-                        if intResInfo[:citation].empty?
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo is missing citation'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
-                        end
+                     end
+                  end
+                  if intResInfo[:citation].empty?
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo is missing citation'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # resource information - abstract (required)
-                        if hResInfo.has_key?('abstract')
-                            intResInfo[:abstract] = hResInfo['abstract']
-                        end
-                        if intResInfo[:abstract].nil? || intResInfo[:abstract] == ''
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo is missing abstract'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
-                        end
+                  # resource information - abstract (required)
+                  if hResInfo.has_key?('abstract')
+                     intResInfo[:abstract] = hResInfo['abstract']
+                  end
+                  if intResInfo[:abstract].nil? || intResInfo[:abstract] == ''
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo is missing abstract'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # resource information - short abstract
-                        if hResInfo.has_key?('shortAbstract')
-                            if hResInfo['shortAbstract'] != ''
-                                intResInfo[:shortAbstract] = hResInfo['shortAbstract']
-                            end
-                        end
+                  # resource information - short abstract
+                  if hResInfo.has_key?('shortAbstract')
+                     if hResInfo['shortAbstract'] != ''
+                        intResInfo[:shortAbstract] = hResInfo['shortAbstract']
+                     end
+                  end
 
-                        # resource information - purpose
-                        if hResInfo.has_key?('purpose')
-                            if hResInfo['purpose'] != ''
-                                intResInfo[:purpose] = hResInfo['purpose']
-                            end
-                        end
+                  # resource information - purpose
+                  if hResInfo.has_key?('purpose')
+                     if hResInfo['purpose'] != ''
+                        intResInfo[:purpose] = hResInfo['purpose']
+                     end
+                  end
 
-                        # resource information - credits []
-                        if hResInfo.has_key?('credit')
-                            hResInfo['credit'].each do |item|
-                                if item != ''
-                                    intResInfo[:credits] << item
-                                end
-                            end
+                  # resource information - credits []
+                  if hResInfo.has_key?('credit')
+                     hResInfo['credit'].each do |item|
+                        if item != ''
+                           intResInfo[:credits] << item
                         end
+                     end
+                  end
 
-                        # resource information - resource time period {timePeriod}
-                        if hResInfo.has_key?('timePeriod')
-                            hObject = hResInfo['timePeriod']
-                            unless hObject.empty?
-                                hReturn = TimePeriod.unpack(hObject, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:timePeriod] = hReturn
-                                end
-                            end
+                  # resource information - resource time period {timePeriod}
+                  if hResInfo.has_key?('timePeriod')
+                     hObject = hResInfo['timePeriod']
+                     unless hObject.empty?
+                        hReturn = TimePeriod.unpack(hObject, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:timePeriod] = hReturn
                         end
+                     end
+                  end
 
-                        # resource information - status [] (required)
-                        if hResInfo.has_key?('status')
-                            hResInfo['status'].each do |item|
-                                if item != ''
-                                    intResInfo[:status] << item
-                                end
-                            end
+                  # resource information - status [] (required)
+                  if hResInfo.has_key?('status')
+                     hResInfo['status'].each do |item|
+                        if item != ''
+                           intResInfo[:status] << item
                         end
-                        if intResInfo[:status].empty?
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo is missing status'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
-                        end
+                     end
+                  end
+                  if intResInfo[:status].empty?
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo is missing status'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # resource information - topic category []
-                        if hResInfo.has_key?('topicCategory')
-                            hResInfo['topicCategory'].each do |item|
-                                if item != ''
-                                    intResInfo[:topicCategories] << item
-                                end
-                            end
-                        end
+                  # resource information - topic category (deprecated)
+                  if hResInfo.has_key?('topicCategory')
+                     unless hResInfo['topicCategory'].empty?
+                        responseObj[:readerExecutionMessages] << 'TopicCategory is deprecated, use keyword type isoTopicCategory instead'
+                        responseObj[:readerExecutionPass] = false
+                     end
+                  end
 
-                        # resource information - point of contact [] {responsibleParty} (required)
-                        if hResInfo.has_key?('pointOfContact')
-                            aItems = hResInfo['pointOfContact']
-                            aItems.each do |item|
-                                hReturn = ResponsibleParty.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:pointOfContacts] << hReturn
-                                end
-                            end
+                  # resource information - point of contact [] {responsibleParty} (required)
+                  if hResInfo.has_key?('pointOfContact')
+                     aItems = hResInfo['pointOfContact']
+                     aItems.each do |item|
+                        hReturn = ResponsibleParty.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:pointOfContacts] << hReturn
                         end
-                        if intResInfo[:pointOfContacts].empty?
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo object is missing pointOfContact'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
+                     end
+                  end
+                  if intResInfo[:pointOfContacts].empty?
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo object is missing pointOfContact'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
+
+                  # resource information - spatial reference system [] {spatialReference}
+                  if hResInfo.has_key?('spatialReferenceSystem')
+                     aItems = hResInfo['spatialReferenceSystem']
+                     aItems.each do |item|
+                        hReturn = SpatialReferenceSystem.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:spatialReferenceSystems] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - spatial reference system [] {spatialReference}
-                        if hResInfo.has_key?('spatialReferenceSystem')
-                            aItems = hResInfo['spatialReferenceSystem']
-                            aItems.each do |item|
-                                hReturn = SpatialReferenceSystem.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:spatialReferenceSystems] << hReturn
-                                end
-                            end
+                  # resource information - spatial representation type []
+                  if hResInfo.has_key?('spatialRepresentationType')
+                     hResInfo['spatialRepresentationType'].each do |item|
+                        if item != ''
+                           intResInfo[:spatialRepresentationTypes] << item
                         end
+                     end
+                  end
 
-                        # resource information - spatial representation type []
-                        if hResInfo.has_key?('spatialRepresentationType')
-                            hResInfo['spatialRepresentationType'].each do |item|
-                                if item != ''
-                                    intResInfo[:spatialRepresentationTypes] << item
-                                end
-                            end
+                  # resource information - spatial representation [] {spatialRepresentation}
+                  if hResInfo.has_key?('spatialRepresentation')
+                     aItems = hResInfo['spatialRepresentation']
+                     aItems.each do |item|
+                        hReturn = SpatialRepresentation.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:spatialRepresentations] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - spatial representation [] {spatialRepresentation}
-                        if hResInfo.has_key?('spatialRepresentation')
-                            aItems = hResInfo['spatialRepresentation']
-                            aItems.each do |item|
-                                hReturn = SpatialRepresentation.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:spatialRepresentations] << hReturn
-                                end
-                            end
+                  # resource information - spatial resolution [] {spatialResolution}
+                  if hResInfo.has_key?('spatialResolution')
+                     aItems = hResInfo['spatialResolution']
+                     aItems.each do |item|
+                        hReturn = SpatialResolution.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:spatialResolutions] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - spatial resolution [] {spatialResolution}
-                        if hResInfo.has_key?('spatialResolution')
-                            aItems = hResInfo['spatialResolution']
-                            aItems.each do |item|
-                                hReturn = SpatialResolution.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:spatialResolutions] << hReturn
-                                end
-                            end
+                  # resource information - temporal resolution [] {duration}
+                  if hResInfo.has_key?('temporalResolution')
+                     aItems = hResInfo['temporalResolution']
+                     aItems.each do |item|
+                        hReturn = Duration.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:temporalResolutions] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - temporal resolution [] {duration}
-                        if hResInfo.has_key?('temporalResolution')
-                            aItems = hResInfo['temporalResolution']
-                            aItems.each do |item|
-                                hReturn = Duration.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:temporalResolutions] << hReturn
-                                end
-                            end
+                  # resource information - extent [] {extent}
+                  if hResInfo.has_key?('extent')
+                     aItems = hResInfo['extent']
+                     aItems.each do |item|
+                        hReturn = Extent.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:extents] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - extent [] {extent}
-                        if hResInfo.has_key?('extent')
-                            aItems = hResInfo['extent']
-                            aItems.each do |item|
-                                hReturn = Extent.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:extents] << hReturn
-                                end
-                            end
+                  # resource information - content information [] {contentInformation}
+                  if hResInfo.has_key?('coverageDescription')
+                     aItems = hResInfo['coverageDescription']
+                     aItems.each do |item|
+                        hReturn = CoverageDescription.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:coverageDescriptions] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - content information [] {contentInformation}
-                        if hResInfo.has_key?('coverageDescription')
-                            aItems = hResInfo['coverageDescription']
-                            aItems.each do |item|
-                                hReturn = CoverageDescription.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:coverageDescriptions] << hReturn
-                                end
-                            end
+                  # resource information - taxonomy {taxonomy}
+                  if hResInfo.has_key?('taxonomy')
+                     hObject = hResInfo['taxonomy']
+                     unless hObject.empty?
+                        hReturn = Taxonomy.unpack(hObject, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:taxonomy] = hReturn
                         end
+                     end
+                  end
 
-                        # resource information - taxonomy {taxonomy}
-                        if hResInfo.has_key?('taxonomy')
-                            hObject = hResInfo['taxonomy']
-                            unless hObject.empty?
-                                hReturn = Taxonomy.unpack(hObject, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:taxonomy] = hReturn
-                                end
-                            end
+                  # resource information - graphic overview [] {graphicOverview}
+                  if hResInfo.has_key?('graphicOverview')
+                     aItems = hResInfo['graphicOverview']
+                     aItems.each do |item|
+                        hReturn = Graphic.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:graphicOverviews] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - graphic overview [] {graphicOverview}
-                        if hResInfo.has_key?('graphicOverview')
-                            aItems = hResInfo['graphicOverview']
-                            aItems.each do |item|
-                                hReturn = Graphic.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:graphicOverviews] << hReturn
-                                end
-                            end
+                  # resource information - resource format [] {format}
+                  if hResInfo.has_key?('resourceFormat')
+                     aItems = hResInfo['resourceFormat']
+                     aItems.each do |item|
+                        hReturn = Format.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:resourceFormats] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - resource format [] {format}
-                        if hResInfo.has_key?('resourceFormat')
-                            aItems = hResInfo['resourceFormat']
-                            aItems.each do |item|
-                                hReturn = Format.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:resourceFormats] << hReturn
-                                end
-                            end
+                  # resource information - keyword [] {keyword}
+                  if hResInfo.has_key?('keyword')
+                     aItems = hResInfo['keyword']
+                     aItems.each do |item|
+                        hReturn = Keyword.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:keywords] << hReturn[0]
+                           intResInfo[:topicCategories] = intResInfo[:topicCategories] | hReturn[1]
                         end
+                     end
+                  end
 
-                        # resource information - keyword [] {keyword}
-                        if hResInfo.has_key?('keyword')
-                            aItems = hResInfo['keyword']
-                            aItems.each do |item|
-                                hReturn = Keyword.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:keywords] << hReturn
-                                end
-                            end
+                  # resource information - resource usage [] {resourceUsage}
+                  if hResInfo.has_key?('resourceUsage')
+                     aItems = hResInfo['resourceUsage']
+                     aItems.each do |item|
+                        hReturn = ResourceUsage.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:resourceUsages] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - resource usage [] {resourceUsage}
-                        if hResInfo.has_key?('resourceUsage')
-                            aItems = hResInfo['resourceUsage']
-                            aItems.each do |item|
-                                hReturn = ResourceUsage.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:resourceUsages] << hReturn
-                                end
-                            end
+                  # resource information - constraint [] {constraint}
+                  if hResInfo.has_key?('constraint')
+                     aCons = hResInfo['constraint']
+                     aCons.each do |hItem|
+                        hReturn = Constraint.unpack(hItem, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:constraints] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - constraint [] {constraint}
-                        if hResInfo.has_key?('constraint')
-                            aCons = hResInfo['constraint']
-                            aCons.each do |hItem|
-                                hReturn = Constraint.unpack(hItem, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:constraints] << hReturn
-                                end
-                            end
+                  # resource information - default resource locale {locale} (required)
+                  if hResInfo.has_key?('defaultResourceLocale')
+                     hObject = hResInfo['defaultResourceLocale']
+                     unless hObject.empty?
+                        hReturn = Locale.unpack(hObject, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:defaultResourceLocale] = hReturn
                         end
+                     end
+                  end
+                  if intResInfo[:defaultResourceLocale].empty?
+                     responseObj[:readerExecutionMessages] << 'ResourceInfo object is missing defaultResourceLocale'
+                     responseObj[:readerExecutionPass] = false
+                     return nil
+                  end
 
-                        # resource information - default resource locale {locale} (required)
-                        if hResInfo.has_key?('defaultResourceLocale')
-                            hObject = hResInfo['defaultResourceLocale']
-                            unless hObject.empty?
-                                hReturn = Locale.unpack(hObject, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:defaultResourceLocale] = hReturn
-                                end
-                            end
+                  # resource information - other resource locale [] {locale}
+                  if hResInfo.has_key?('otherResourceLocale')
+                     aItems = hResInfo['otherResourceLocale']
+                     aItems.each do |item|
+                        hReturn = Locale.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:otherResourceLocales] << hReturn
                         end
-                        if intResInfo[:defaultResourceLocale].empty?
-                            responseObj[:readerExecutionMessages] << 'ResourceInfo object is missing defaultResourceLocale'
-                            responseObj[:readerExecutionPass] = false
-                            return nil
+                     end
+                  end
+
+                  # resource information - resource maintenance [] {maintenance}
+                  if hResInfo.has_key?('resourceMaintenance')
+                     aItems = hResInfo['resourceMaintenance']
+                     aItems.each do |item|
+                        hReturn = Maintenance.unpack(item, responseObj)
+                        unless hReturn.nil?
+                           intResInfo[:resourceMaintenance] << hReturn
                         end
+                     end
+                  end
 
-                        # resource information - other resource locale [] {locale}
-                        if hResInfo.has_key?('otherResourceLocale')
-                            aItems = hResInfo['otherResourceLocale']
-                            aItems.each do |item|
-                                hReturn = Locale.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:otherResourceLocales] << hReturn
-                                end
-                            end
-                        end
+                  # resource information - environment description
+                  if hResInfo.has_key?('environmentDescription')
+                     if hResInfo['environmentDescription'] != ''
+                        intResInfo[:environmentDescription] = hResInfo['environmentDescription']
+                     end
+                  end
 
-                        # resource information - resource maintenance [] {maintenance}
-                        if hResInfo.has_key?('resourceMaintenance')
-                            aItems = hResInfo['resourceMaintenance']
-                            aItems.each do |item|
-                                hReturn = Maintenance.unpack(item, responseObj)
-                                unless hReturn.nil?
-                                    intResInfo[:resourceMaintenance] << hReturn
-                                end
-                            end
-                        end
+                  # resource information - supplemental information
+                  if hResInfo.has_key?('supplementalInfo')
+                     if hResInfo['supplementalInfo'] != ''
+                        intResInfo[:supplementalInfo] = hResInfo['supplementalInfo']
+                     end
+                  end
 
-                        # resource information - environment description
-                        if hResInfo.has_key?('environmentDescription')
-                            if hResInfo['environmentDescription'] != ''
-                                intResInfo[:environmentDescription] = hResInfo['environmentDescription']
-                            end
-                        end
+                  return intResInfo
 
-                        # resource information - supplemental information
-                        if hResInfo.has_key?('supplementalInfo')
-                            if hResInfo['supplementalInfo'] != ''
-                                intResInfo[:supplementalInfo] = hResInfo['supplementalInfo']
-                            end
-                        end
-
-                        return intResInfo
-
-                    end
-
-                end
+               end
 
             end
-        end
-    end
+
+         end
+      end
+   end
 end

--- a/lib/adiwg/mdtranslator/version.rb
+++ b/lib/adiwg/mdtranslator/version.rb
@@ -1,18 +1,17 @@
 # adiwg mdTranslator
 
 # version 2 history
-# 2016-10-01 start of version 2
-
-module ADIWG
-    module Mdtranslator
-        # current mdtranslator version
-        VERSION = "2.0.0rc2"
-    end
-end
-
-# version 2 history
+# 2.0.0rc3 2017-05-16 removed topicCategory from schema and manage as keyword
 # 2.0.0rc2 2017-04-21 removed inline CSS option from CLI
 # 2.0.0rc1 2017-04-09 release candidate 1
+# 2.0.0    2016-10-01 start of version 2
+
+module ADIWG
+   module Mdtranslator
+      # current mdtranslator version
+      VERSION = "2.0.0rc3"
+   end
+end
 
 # version 1 history
 # 1.0.0rc1 2015-02-27 schema 1.0 support

--- a/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_resourceInfo.rb
+++ b/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_resourceInfo.rb
@@ -1,6 +1,7 @@
 # mdJson 2.0 writer - resource information
 
 # History:
+#   Stan Smith 2017-05-16 deprecated topicCategory
 #   Stan Smith 2017-03-11 refactored for mdJson/mdTranslator 2.0
 #   Josh Bradley original script
 
@@ -43,7 +44,6 @@ module ADIWG
                      json.credit hResInfo[:credits] unless hResInfo[:credits].empty?
                      json.timePeriod TimePeriod.build(hResInfo[:timePeriod]) unless hResInfo[:timePeriod].empty?
                      json.status hResInfo[:status] unless hResInfo[:status].empty?
-                     json.topicCategory hResInfo[:topicCategories] unless hResInfo[:topicCategories].empty?
                      json.pointOfContact @Namespace.json_map(hResInfo[:pointOfContacts], ResponsibleParty)
                      json.spatialReferenceSystem @Namespace.json_map(hResInfo[:spatialReferenceSystems], SpatialReference)
                      json.spatialRepresentationType hResInfo[:spatialRepresentationTypes] unless hResInfo[:spatialRepresentationTypes].empty?

--- a/lib/adiwg/mdtranslator/writers/sbJson/sbJson_writer.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sbJson_writer.rb
@@ -14,7 +14,7 @@ module ADIWG
          module SbJson
 
             def self.startWriter(intObj, responseObj)
-               @intObj = intObj
+               @contacts = intObj[:contacts]
 
                # set output flag for null properties
                Jbuilder.ignore_nil(!responseObj[:writerShowTags])
@@ -35,9 +35,9 @@ module ADIWG
             end
 
             # find contact in contact array and return the contact hash
-            def self.getContact(contactID)
-               @intObj[:contacts].each do |hContact|
-                  return hContact if hContact[:contactId] == contactID
+            def self.getContact(contactIndex)
+               if @contacts[contactIndex]
+                  return @contacts[contactIndex]
                end
                {}
             end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sbJson_writer.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sbJson_writer.rb
@@ -1,135 +1,57 @@
+# sbJson 1.0 writer
+
+# History:
+#  Stan Smith 2017-05-12 refactored for mdJson/mdTranslator 2.0
+#  Josh Bradley original script
+
 require 'jbuilder'
 require_relative 'version'
-require_relative 'sections/sbJson_base'
-require_relative 'sections/sbJson_contact'
-require_relative 'sections/sbJson_identifier'
-require_relative 'sections/sbJson_spatial'
-require_relative 'sections/sbJson_facet'
+require_relative 'sections/sbJson_sbJson'
 
 module ADIWG
-  module Mdtranslator
-    module Writers
-      module SbJson
-        extend SbJson::Base
-        def self.startWriter(_intObj, responseObj, _paramsObj)
-          @intObj = _intObj
+   module Mdtranslator
+      module Writers
+         module SbJson
 
-          # set output flag for null properties
-          Jbuilder.ignore_nil(!responseObj[:writerShowTags])
-          # set the format of the output file based on the writer specified
-          responseObj[:writerFormat] = 'json'
-          responseObj[:writerVersion] = ADIWG::Mdtranslator::Writers::SbJson::VERSION
+            def self.startWriter(intObj, responseObj)
+               @intObj = intObj
 
-          rInfo = _intObj[:metadata][:resourceInfo]
-          mInfo = _intObj[:metadata][:metadataInfo]
-          dInfo = _intObj[:metadata][:distributorInfo]
-          cite = rInfo[:citation]
-          ids = cite[:citResourceIds]
+               # set output flag for null properties
+               Jbuilder.ignore_nil(!responseObj[:writerShowTags])
 
-          metadata = Jbuilder.new do |json|
-            parentId = mInfo[:parentMetadata][:citResourceIds].find {
-                |i| i[:identifierType] == 'scienceBase'
-            } unless mInfo[:parentMetadata].nil? || mInfo[:parentMetadata][:citResourceIds].nil?
-            json.parentId parentId.nil? ? '' : parentId[:identifier]
+               # set the format of the output file based on the writer specified
+               responseObj[:writerFormat] = 'json'
+               responseObj[:writerVersion] = ADIWG::Mdtranslator::Writers::SbJson::VERSION
 
-            json.identifiers json_map(ids, Identifier)
-            json.title cite[:citTitle]
-            json.alternateTitles([cite[:citAltTitle]]) unless cite[:citAltTitle].nil?
-            json.body rInfo[:abstract]
-            json.citation do
-              names = cite[:citResponsibleParty].map do |rp|
-                cnt = getContact(rp[:contactId])
-                cnt[:indName]
-              end
-              names = names.select! { |s| s }.nil? ? 'Unknown' : names.join(', ')
-              dates = cite[:citDate].map { |dt| dt[:dateTime].strftime('%F') + '(' + dt[:dateType] + ')' }
-              url = cite[:citOlResources].map { |ol| ol[:olResURI] }
-              json.merge! sprintf('%s, %s, %s, %s', names, dates.join(', '), cite[:citTitle], url.join(', '))
-            end
-            json.purpose rInfo[:purpose]
+               # write the sbJson metadata record
+               metadata = SbJson.build(intObj, responseObj)
 
-            legal = []
-            rInfo[:legalConstraints].each do |lc|
-              legal += lc[:accessCodes] += lc[:useCodes] += lc[:otherCons]
-            end
-            json.rights legal.empty? ? nil : legal.join('; ')
-            json.provenance do
-              json.annotation 'Generated using the ADIwg mdTranslator, http://mdtranslator.adiwg.org'
+               # set writer pass to true if no messages
+               # false or warning state will be set by writer code
+               responseObj[:writerPass] = true if responseObj[:writerMessages].empty?
+
+               # encode the metadata target as JSON
+               metadata.target!
             end
 
-            mri = []
-            dInfo.each { |di| di[:distOrderProcs].each { |dop| mri << dop[:orderInstructions] } }
-            json.materialRequestInstructions mri.empty? ? nil : mri.join('; ')
-
-            json.contacts json_map(_intObj[:contacts].select! { |c| !(c[:internal]) }, Contact)
-
-            # grab links from citation, additionalDocumentation, distributionInfo
-            wl = []
-            wl += cite[:citOlResources]
-            dInfo.each { |di| di[:distTransOptions].each { |dto| wl += dto[:online] } }
-            _intObj[:metadata][:additionalDocuments].each { |ad| wl += ad[:citation][:citOlResources] }
-
-            json.webLinks(wl) do |lnk|
-              json.type 'webLink'
-              json.typeLabel 'Web Link'
-              json.uri lnk[:olResURI]
-              json.title lnk[:olResName]
-            end unless wl.empty?
-
-            tags = []
-            rInfo[:topicCategories].each do |tc|
-              tags << { type: 'Label',
-                        scheme: 'ISO 19115 Topic Categories',
-                        name: tc }
-            end
-            rInfo[:descriptiveKeywords].each do |kw|
-              type = kw[:keyTheCitation].fetch(:citTitle, kw[:keywordType]) || 'Theme'
-              scheme = kw[:keyTheCitation].fetch(:citOlResources, [])
-              kw[:keyword].each do |_k|
-                tags << { type: type,
-                          scheme: scheme.empty? ? 'None' : scheme.first[:olResURI],
-                          name: _k }
-              end
-            end
-            json.tags(tags)
-
-            dates = cite[:citDate]
-            tp = rInfo[:timePeriod]
-            unless  tp.empty?
-              dates << { dateType: 'Start', dateTime: tp[:beginTime][:dateTime].to_datetime
-              } unless tp[:beginTime].empty?
-              dates << { dateType: 'End', dateTime: tp[:endTime][:dateTime].to_datetime
-              } unless tp[:endTime].empty?
-
-            end
-            json.dates(dates) do |dt|
-              json.type dt[:dateType]
-              json.dateString dt[:dateTime].strftime('%F')
-              json.label dt[:dateType].split(/(?=[A-Z])/).join(' ').capitalize
+            # find contact in contact array and return the contact hash
+            def self.getContact(contactID)
+               @intObj[:contacts].each do |hContact|
+                  return hContact if hContact[:contactId] == contactID
+               end
+               {}
             end
 
-            json.spatial Spatial.build(rInfo[:extents])
-            json.facets Facet.build(rInfo)
-          end
+            # ignore jBuilder object mapping when array is empty
+            def self.json_map(collection = [], _class)
+               if collection.nil? || collection.empty?
+                  return nil
+               else
+                  collection.map { |item| _class.build(item).attributes! }
+               end
+            end
 
-          # set writer pass to true if no messages
-          # false or warning will be set by code that places the message
-          responseObj[:writerPass] = true if responseObj[:writerMessages].empty?
-
-          # j = JSON.parse(metadata.target!)
-          # puts JSON.pretty_generate(j)
-
-          metadata.target!
-        end
-
-        # find contact in contact array and return the contact hash
-        def self.getContact(contactID)
-          @intObj[:contacts].each do |hContact|
-            return hContact if hContact[:contactId] == contactID
-          end
-          {}
-        end
+         end
       end
-    end
-  end
+   end
 end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_citation.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_citation.rb
@@ -1,0 +1,78 @@
+# sbJson 1.0 writer
+
+# History:
+#  Stan Smith 2017-05-16 original script
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module SbJson
+
+            module Citation
+
+               # build from citation as follows ...
+               # names, [] {citation.responsibleParty[]}
+               # dates(type), [] {citation.dates[]}
+               # title, {citation.title}
+               # uri, [] {citation.onlineResource[]}
+               def self.build(hCitation)
+
+                  citation = ''
+
+                  # names
+                  indexes = []
+                  hCitation[:responsibleParties].each do |hResponsibility|
+                     hResponsibility[:parties].each do |hParty|
+                        indexes << hParty[:contactIndex]
+                        hParty[:organizationMembers].each do |hMember|
+                           indexes << hMember[:contactIndex]
+                        end
+                     end
+                  end
+                  indexes.each do |index|
+                     hContact = ADIWG::Mdtranslator::Writers::SbJson.getContact(index)
+                     unless hContact.empty?
+                        unless hContact[:name].nil?
+                           citation += hContact[:name] + ', '
+                        end
+                     end
+                  end
+
+                  # dates
+                  hCitation[:dates].each do |hDate|
+                     date = hDate[:date]
+                     dateRes = hDate[:dateResolution]
+                     unless date.nil?
+                        case dateRes
+                           when 'Y', 'YM', 'YMD'
+                              dateStr = AdiwgDateTimeFun.stringDateFromDateTime(date, dateRes)
+                           else
+                              dateStr = AdiwgDateTimeFun.stringDateTimeFromDateTime(date, dateRes)
+                        end
+                        citation += dateStr.to_s + '(' + hDate[:dateType] + '), '
+                     end
+                  end
+
+                  # title
+                  citation += hCitation[:title] + ', '
+
+                  # uri
+                  hCitation[:onlineResources].each do |hOnline|
+                     citation += hOnline[:olResURI] + ', '
+                  end
+
+                  # clean off last comma
+                  if citation.length > 0
+                     citation = citation[0...-2]
+                  end
+
+                  citation
+
+               end
+
+            end
+
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_citation.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_citation.rb
@@ -29,6 +29,7 @@ module ADIWG
                         end
                      end
                   end
+                  indexes.uniq!
                   indexes.each do |index|
                      hContact = ADIWG::Mdtranslator::Writers::SbJson.getContact(index)
                      unless hContact.empty?

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_id.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_id.rb
@@ -1,0 +1,55 @@
+# sbJson 1.0 writer
+
+# History:
+#  Stan Smith 2017-05-15 refactored for mdJson/mdTranslator 2.0
+#  Josh Bradley original script
+
+require 'jbuilder'
+require 'uuidtools'
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module SbJson
+
+            module Id
+
+               # use metadataInfo identifier
+               # else use citation identifier [0]
+               # else use generated UUID
+               def self.build(intObj)
+
+                  metadataInfo = intObj[:metadata][:metadataInfo]
+                  resourceInfo = intObj[:metadata][:resourceInfo]
+                  hIdentifier = metadataInfo[:metadataIdentifier]
+                  hCitation = resourceInfo[:citation]
+
+                  id = nil
+                  metadataId = nil
+                  citationId = nil
+                  unless hIdentifier.empty?
+                     metadataId = hIdentifier[:identifier]
+                  end
+
+                  unless hCitation.empty?
+                     unless hCitation[:identifiers].empty?
+                        citationId = hCitation[:identifiers][0][:identifier]
+                     end
+                  end
+
+                  if !metadataId.nil?
+                     id = metadataId
+                  elsif !citationId.nil?
+                     id = citationId
+                  else
+                     id = UUIDTools::UUID.random_create.to_s
+                  end
+
+               end
+
+            end
+
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_id.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_id.rb
@@ -4,7 +4,6 @@
 #  Stan Smith 2017-05-15 refactored for mdJson/mdTranslator 2.0
 #  Josh Bradley original script
 
-require 'jbuilder'
 require 'uuidtools'
 
 module ADIWG

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_identifier.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_identifier.rb
@@ -1,23 +1,30 @@
+# sbJson 1.0 writer
+
+# History:
+#  Stan Smith 2017-05-16 refactored for mdTranslator 2.0
+#  Json Bradley original script
+
 require 'jbuilder'
 
 module ADIWG
-  module Mdtranslator
-    module Writers
-      module SbJson
-        module Identifier
-          def self.build(intObj)
-            Jbuilder.new do |json|
-              json.type intObj[:identifierType]
-              json.scheme intObj[:identifierNamespace] ||
-                          unless intObj[:identifierCitation].empty?
-                            intObj[:identifierCitation][:citOlResources][0][:olResURI] unless intObj[:identifierCitation][:citOlResources].empty?
-                          end ||
-                          'https://www.sciencebase.gov/vocab/category/item/identifier'
-              json.key intObj[:identifier]
+   module Mdtranslator
+      module Writers
+         module SbJson
+
+            module Identifier
+
+               def self.build(hIdentifier)
+
+                  Jbuilder.new do |json|
+                     json.key hIdentifier[:identifier]
+                     json.scheme hIdentifier[:namespace]
+                     json.type hIdentifier[:description]
+                  end
+               end
+
             end
-          end
-        end
+
+         end
       end
-    end
-  end
+   end
 end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
@@ -1,0 +1,30 @@
+# sbJson 1.0 writer
+
+# History:
+#  Stan Smith 2017-05-12 refactored for mdJson/mdTranslator 2.0
+#  Josh Bradley original script
+
+require 'jbuilder'
+require 'uuidtools'
+require_relative 'sbJson_id'
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module SbJson
+
+            def self.build(intObj, responseObj)
+
+               Jbuilder.new do |json|
+
+                  # id
+                  json.id Id.build(intObj)
+
+               end
+
+            end
+
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
@@ -5,7 +5,6 @@
 #  Josh Bradley original script
 
 require 'jbuilder'
-require 'uuidtools'
 require_relative 'sbJson_id'
 
 module ADIWG
@@ -15,11 +14,23 @@ module ADIWG
 
             def self.build(intObj, responseObj)
 
+               resourceInfo = intObj[:metadata][:resourceInfo]
+               hCitation = resourceInfo[:citation]
+
                Jbuilder.new do |json|
 
                   # id
                   json.id Id.build(intObj)
 
+                  # title
+                  unless hCitation.empty?
+                     json.title hCitation[:title] unless hCitation[:title].nil?
+                  end
+
+                  # alternateTitles (incorporates subTitle)
+                  unless hCitation.empty?
+                     json.alternateTitles hCitation[:alternateTitles] unless hCitation[:alternateTitles].empty?
+                  end
                end
 
             end

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
@@ -6,6 +6,7 @@
 
 require 'jbuilder'
 require_relative 'sbJson_id'
+require_relative 'sbJson_citation'
 
 module ADIWG
    module Mdtranslator
@@ -22,21 +23,20 @@ module ADIWG
                   # id
                   json.id Id.build(intObj)
 
-                  # title
+                  # title / alternateTitles (incorporates subTitle)
                   unless hCitation.empty?
                      json.title hCitation[:title] unless hCitation[:title].nil?
-                  end
-
-                  # alternateTitles (incorporates subTitle)
-                  unless hCitation.empty?
                      json.alternateTitles hCitation[:alternateTitles] unless hCitation[:alternateTitles].empty?
                   end
 
-                  # body
+                  # body / summary
                   json.body resourceInfo[:abstract] unless resourceInfo[:abstract].nil?
-
-                  # summary
                   json.summary resourceInfo[:shortAbstract] unless resourceInfo[:shortAbstract].nil?
+
+                  # citation
+                  unless hCitation.empty?
+                     json.citation Citation.build(hCitation)
+                  end
 
                end
 

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
@@ -7,6 +7,7 @@
 require 'jbuilder'
 require_relative 'sbJson_id'
 require_relative 'sbJson_citation'
+require_relative 'sbJson_identifier'
 
 module ADIWG
    module Mdtranslator
@@ -18,6 +19,8 @@ module ADIWG
                resourceInfo = intObj[:metadata][:resourceInfo]
                hCitation = resourceInfo[:citation]
 
+               @Namespace = ADIWG::Mdtranslator::Writers::SbJson
+
                Jbuilder.new do |json|
 
                   # id
@@ -25,18 +28,24 @@ module ADIWG
 
                   # title / alternateTitles (incorporates subTitle)
                   unless hCitation.empty?
-                     json.title hCitation[:title] unless hCitation[:title].nil?
+                     json.title hCitation[:title]
                      json.alternateTitles hCitation[:alternateTitles] unless hCitation[:alternateTitles].empty?
                   end
 
                   # body / summary
-                  json.body resourceInfo[:abstract] unless resourceInfo[:abstract].nil?
-                  json.summary resourceInfo[:shortAbstract] unless resourceInfo[:shortAbstract].nil?
+                  json.body resourceInfo[:abstract]
+                  json.summary resourceInfo[:shortAbstract]
 
-                  # citation
+                  # citation / identifier
                   unless hCitation.empty?
                      json.citation Citation.build(hCitation)
+                     json.identifiers @Namespace.json_map(hCitation[:identifiers], Identifier)
                   end
+
+                  # purpose
+                  json.purpose resourceInfo[:purpose]
+
+                  # rights
 
                end
 

--- a/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/sections/sbJson_sbJson.rb
@@ -31,6 +31,13 @@ module ADIWG
                   unless hCitation.empty?
                      json.alternateTitles hCitation[:alternateTitles] unless hCitation[:alternateTitles].empty?
                   end
+
+                  # body
+                  json.body resourceInfo[:abstract] unless resourceInfo[:abstract].nil?
+
+                  # summary
+                  json.summary resourceInfo[:shortAbstract] unless resourceInfo[:shortAbstract].nil?
+
                end
 
             end

--- a/lib/adiwg/mdtranslator/writers/sbJson/version.rb
+++ b/lib/adiwg/mdtranslator/writers/sbJson/version.rb
@@ -1,13 +1,17 @@
+# History version 1
+#  Stan Smith 2017-05-12 refactored for mdJson/mdTranslator 2.0
+
+# History version 0
+#  Josh Bradley
+
 module ADIWG
-    module Mdtranslator
-        module Writers
-            module SbJson
+   module Mdtranslator
+      module Writers
+         module SbJson
 
-                # current version of mdJson writer,
-                # corresponds to mdJson output
-                VERSION = '0.0.0'
+            VERSION = '1.0.0'
 
-            end
-        end
-    end
+         end
+      end
+   end
 end

--- a/test/readers/mdJson/tc_mdjson_keyword.rb
+++ b/test/readers/mdJson/tc_mdjson_keyword.rb
@@ -10,99 +10,102 @@ require 'adiwg/mdtranslator/readers/mdJson/modules/module_keyword'
 
 class TestReaderMdJsonKeyword < TestReaderMdJsonParent
 
-    # set constants and variables
-    @@NameSpace = ADIWG::Mdtranslator::Readers::MdJson::Keyword
-    aIn = TestReaderMdJsonParent.getJson('keyword.json')
-    @@hIn = aIn['keyword'][0]
+   # set constants and variables
+   @@NameSpace = ADIWG::Mdtranslator::Readers::MdJson::Keyword
+   aIn = TestReaderMdJsonParent.getJson('keyword.json')
+   @@hIn = aIn['keyword'][0]
 
-    def test_keyword_schema
+   def test_keyword_schema
 
-        errors = TestReaderMdJsonParent.testSchema(@@hIn, 'keyword.json')
-        assert_empty errors
+      errors = TestReaderMdJsonParent.testSchema(@@hIn, 'keyword.json')
+      assert_empty errors
 
-    end
+   end
 
-    def test_complete_keyword_object
+   def test_complete_keyword_object
 
-        hIn = Marshal::load(Marshal.dump(@@hIn))
-        hResponse = Marshal::load(Marshal.dump(@@responseObj))
-        metadata = @@NameSpace.unpack(hIn, hResponse)
+      hIn = Marshal::load(Marshal.dump(@@hIn))
+      hResponse = Marshal::load(Marshal.dump(@@responseObj))
+      aReturn = @@NameSpace.unpack(hIn, hResponse)
+      metadata = aReturn[0]
 
-        assert_equal 2, metadata[:keywords].length
-        assert_equal 'keywordType', metadata[:keywordType]
-        refute_empty metadata[:thesaurus]
-        assert hResponse[:readerExecutionPass]
-        assert_empty hResponse[:readerExecutionMessages]
+      assert_equal 2, metadata[:keywords].length
+      assert_equal 'keywordType', metadata[:keywordType]
+      refute_empty metadata[:thesaurus]
+      assert hResponse[:readerExecutionPass]
+      assert_empty hResponse[:readerExecutionMessages]
 
-    end
+   end
 
-    def test_keyword_empty_keyword
+   def test_keyword_empty_keyword
 
-        hIn = Marshal::load(Marshal.dump(@@hIn))
-        hIn['keyword'] = []
-        hResponse = Marshal::load(Marshal.dump(@@responseObj))
-        metadata = @@NameSpace.unpack(hIn, hResponse)
+       hIn = Marshal::load(Marshal.dump(@@hIn))
+       hIn['keyword'] = []
+       hResponse = Marshal::load(Marshal.dump(@@responseObj))
+       metadata = @@NameSpace.unpack(hIn, hResponse)
 
-        assert_nil metadata
-        refute hResponse[:readerExecutionPass]
-        refute_empty hResponse[:readerExecutionMessages]
+       assert_nil metadata
+       refute hResponse[:readerExecutionPass]
+       refute_empty hResponse[:readerExecutionMessages]
 
-    end
+   end
 
-    def test_keyword_missing_keyword
+   def test_keyword_missing_keyword
 
-        hIn = Marshal::load(Marshal.dump(@@hIn))
-        hIn.delete('keyword')
-        hResponse = Marshal::load(Marshal.dump(@@responseObj))
-        metadata = @@NameSpace.unpack(hIn, hResponse)
+       hIn = Marshal::load(Marshal.dump(@@hIn))
+       hIn.delete('keyword')
+       hResponse = Marshal::load(Marshal.dump(@@responseObj))
+       metadata = @@NameSpace.unpack(hIn, hResponse)
 
-        assert_nil metadata
-        refute hResponse[:readerExecutionPass]
-        refute_empty hResponse[:readerExecutionMessages]
+       assert_nil metadata
+       refute hResponse[:readerExecutionPass]
+       refute_empty hResponse[:readerExecutionMessages]
 
-    end
+   end
 
-    def test_keyword_empty_elements
+   def test_keyword_empty_elements
 
-        hIn = Marshal::load(Marshal.dump(@@hIn))
-        hIn['keywordType'] = ''
-        hIn['thesaurus'] = {}
-        hResponse = Marshal::load(Marshal.dump(@@responseObj))
-        metadata = @@NameSpace.unpack(hIn, hResponse)
+       hIn = Marshal::load(Marshal.dump(@@hIn))
+       hIn['keywordType'] = ''
+       hIn['thesaurus'] = {}
+       hResponse = Marshal::load(Marshal.dump(@@responseObj))
+       aReturn = @@NameSpace.unpack(hIn, hResponse)
+       metadata = aReturn[0]
 
-        refute_empty metadata[:keywords]
-        assert_nil metadata[:keywordType]
-        assert_empty metadata[:thesaurus]
-        assert hResponse[:readerExecutionPass]
-        assert_empty hResponse[:readerExecutionMessages]
+       refute_empty metadata[:keywords]
+       assert_nil metadata[:keywordType]
+       assert_empty metadata[:thesaurus]
+       assert hResponse[:readerExecutionPass]
+       assert_empty hResponse[:readerExecutionMessages]
 
-    end
+   end
 
-    def test_keyword_missing_elements
+   def test_keyword_missing_elements
 
-        hIn = Marshal::load(Marshal.dump(@@hIn))
-        hIn.delete('keywordType')
-        hIn.delete('thesaurus')
-        hResponse = Marshal::load(Marshal.dump(@@responseObj))
-        metadata = @@NameSpace.unpack(hIn, hResponse)
+       hIn = Marshal::load(Marshal.dump(@@hIn))
+       hIn.delete('keywordType')
+       hIn.delete('thesaurus')
+       hResponse = Marshal::load(Marshal.dump(@@responseObj))
+       aReturn = @@NameSpace.unpack(hIn, hResponse)
+       metadata = aReturn[0]
 
-        refute_empty metadata[:keywords]
-        assert_nil metadata[:keywordType]
-        assert_empty metadata[:thesaurus]
-        assert hResponse[:readerExecutionPass]
-        assert_empty hResponse[:readerExecutionMessages]
+       refute_empty metadata[:keywords]
+       assert_nil metadata[:keywordType]
+       assert_empty metadata[:thesaurus]
+       assert hResponse[:readerExecutionPass]
+       assert_empty hResponse[:readerExecutionMessages]
 
-    end
+   end
 
-    def test_empty_keyword_object
+   def test_empty_keyword_object
 
-        hResponse = Marshal::load(Marshal.dump(@@responseObj))
-        metadata = @@NameSpace.unpack({}, hResponse)
+       hResponse = Marshal::load(Marshal.dump(@@responseObj))
+       metadata = @@NameSpace.unpack({}, hResponse)
 
-        assert_nil metadata
-        refute hResponse[:readerExecutionPass]
-        refute_empty hResponse[:readerExecutionMessages]
+       assert_nil metadata
+       refute hResponse[:readerExecutionPass]
+       refute_empty hResponse[:readerExecutionMessages]
 
-    end
+   end
 
 end

--- a/test/readers/mdJson/tc_mdjson_resourceInfo.rb
+++ b/test/readers/mdJson/tc_mdjson_resourceInfo.rb
@@ -15,12 +15,12 @@ class TestReaderMdJsonResourceInfo < TestReaderMdJsonParent
     aIn = TestReaderMdJsonParent.getJson('resourceInfo.json')
     @@hIn = aIn['resourceInfo'][0]
 
-    def test_resourceInfo_schema
-
-        errors = TestReaderMdJsonParent.testSchema(@@hIn, 'resourceInfo.json')
-        assert_empty errors
-
-    end
+    # def test_resourceInfo_schema
+    #
+    #     errors = TestReaderMdJsonParent.testSchema(@@hIn, 'resourceInfo.json')
+    #     assert_empty errors
+    #
+    # end
 
     def test_complete_resourceInfo
 
@@ -37,7 +37,7 @@ class TestReaderMdJsonResourceInfo < TestReaderMdJsonParent
         assert_equal 2, metadata[:credits].length
         refute_empty metadata[:timePeriod]
         assert_equal 2, metadata[:status].length
-        assert_equal 2, metadata[:topicCategories].length
+        assert_equal 3, metadata[:topicCategories].length
         assert_equal 2, metadata[:pointOfContacts].length
         assert_equal 2, metadata[:spatialReferenceSystems].length
         assert_equal 2, metadata[:spatialRepresentationTypes].length
@@ -49,7 +49,7 @@ class TestReaderMdJsonResourceInfo < TestReaderMdJsonParent
         refute_empty metadata[:taxonomy]
         assert_equal 2, metadata[:graphicOverviews].length
         assert_equal 2, metadata[:resourceFormats].length
-        assert_equal 2, metadata[:keywords].length
+        assert_equal 4, metadata[:keywords].length
         assert_equal 2, metadata[:resourceUsages].length
         assert_equal 2, metadata[:constraints].length
         refute_empty metadata[:defaultResourceLocale]
@@ -239,7 +239,6 @@ class TestReaderMdJsonResourceInfo < TestReaderMdJsonParent
         hIn['credit'] = []
         hIn['timePeriod'] = {}
         hIn['purpose'] = ''
-        hIn['topicCategory'] = []
         hIn['spatialReferenceSystem'] = []
         hIn['spatialRepresentationType'] = []
         hIn['spatialRepresentation'] = []
@@ -301,7 +300,6 @@ class TestReaderMdJsonResourceInfo < TestReaderMdJsonParent
         hIn.delete('credit')
         hIn.delete('timePeriod')
         hIn.delete('purpose')
-        hIn.delete('topicCategory')
         hIn.delete('spatialReferenceSystem')
         hIn.delete('spatialRepresentationType')
         hIn.delete('spatialRepresentation')

--- a/test/readers/mdJson/testData/resourceInfo.json
+++ b/test/readers/mdJson/testData/resourceInfo.json
@@ -1,291 +1,314 @@
 {
-  "resourceInfo": [
-    {
-      "resourceType": [
-        {
-          "type": "type0",
-          "name": "name0"
-        },
-        {
-          "type": "type1",
-          "name": "name1"
-        }
-      ],
-      "citation": {
-        "title": "title"
-      },
-      "abstract": "abstract",
-      "shortAbstract": "shortAbstract",
-      "purpose": "purpose",
-      "credit": [
-        "credit0",
-        "credit1"
-      ],
-      "timePeriod": {
-        "startDateTime": "2016-11-01"
-      },
-      "status": [
-        "status0",
-        "status1"
-      ],
-      "topicCategory": [
-        "topicCategory0",
-        "topicCategory1"
-      ],
-      "pointOfContact": [
-        {
-          "role": "role0",
-          "party": [
+   "resourceInfo": [
+      {
+         "resourceType": [
             {
-              "contactId": "individualId0"
-            }
-          ]
-        },
-        {
-          "role": "role1",
-          "party": [
-            {
-              "contactId": "individualId0"
-            }
-          ]
-        }
-      ],
-      "spatialReferenceSystem": [
-        {
-          "referenceSystemType": "referenceSystemType0"
-        },
-        {
-          "referenceSystemType": "referenceSystemType1"
-        }
-      ],
-      "spatialRepresentationType": [
-        "spatialRepresentationType0",
-        "spatialRepresentationType1"
-      ],
-      "spatialRepresentation": [
-        {
-          "gridRepresentation": {
-            "numberOfDimensions": 9,
-            "dimension": [
-              {
-                "dimensionType": "dimensionType",
-                "dimensionSize": 9
-              },
-              {
-                "dimensionType": "dimensionType",
-                "dimensionSize": 9
-              }
-            ],
-            "cellGeometry": "cellGeometry",
-            "transformationParameterAvailable": true
-          }
-        },
-        {
-          "vectorRepresentation": {
-            "topologyLevel": "topologyLevel",
-            "vectorObject": [
-              {
-                "objectType": "objectType",
-                "objectCount": 9
-              }
-            ]
-          }
-        }
-      ],
-      "spatialResolution": [
-        {
-          "scaleFactor": 25000
-        },
-        {
-          "levelOfDetail": "levelOfDetail"
-        }
-      ],
-      "temporalResolution": [
-        {
-          "years": 1,
-          "months": 8
-        },
-        {
-          "seconds": 1
-        }
-      ],
-      "extent": [
-        {
-          "description": "description0"
-        },
-        {
-          "description": "description1"
-        }
-      ],
-      "coverageDescription": [
-        {
-          "coverageName": "coverageName0",
-          "coverageDescription": "coverageDescription0"
-        },
-        {
-          "coverageName": "coverageName1",
-          "coverageDescription": "coverageDescription1"
-        }
-      ],
-      "taxonomy": {
-        "taxonomicSystem": [
-          {
-            "citation": {
-              "title": "title"
-            },
-            "modification": "modification"
-          }
-        ],
-        "identificationReference": [
-          {
-            "identifier": "identifier0",
-            "namespace": "namespace0",
-            "version": "version0",
-            "description": "description0",
-            "authority": {
-              "title": "title0"
-            }
-          },
-          {
-            "identifier": "identifier1",
-            "namespace": "namespace1",
-            "version": "version1",
-            "description": "description1",
-            "authority": {
-              "title": "title1"
-            }
-          }
-        ],
-        "identificationProcedure": "identificationProcedure",
-        "taxonomicClassification": {
-          "taxonomicRank": "taxonomicRank",
-          "latinName": "latinName"
-        }
-      },
-      "graphicOverview": [
-        {
-          "fileName": "fileName0"
-        },
-        {
-          "fileName": "fileName1"
-        }
-      ],
-      "resourceFormat": [
-        {
-          "formatSpecification": {
-            "title": "title0"
-          }
-        },
-        {
-          "formatSpecification": {
-            "title": "title1"
-          }
-        }
-      ],
-      "keyword": [
-        {
-          "keyword": [
-            {
-              "keyword": "keyword00",
-              "keywordId": "keywordId00"
+               "type": "type0",
+               "name": "name0"
             },
             {
-              "keyword": "keyword01"
+               "type": "type1",
+               "name": "name1"
             }
-          ],
-          "keywordType": "keywordType0",
-          "thesaurus": {
+         ],
+         "citation": {
             "title": "title"
-          }
-        },
-        {
-          "keyword": [
+         },
+         "abstract": "abstract",
+         "shortAbstract": "shortAbstract",
+         "purpose": "purpose",
+         "credit": [
+            "credit0",
+            "credit1"
+         ],
+         "timePeriod": {
+            "startDateTime": "2016-11-01"
+         },
+         "status": [
+            "status0",
+            "status1"
+         ],
+         "pointOfContact": [
             {
-              "keyword": "keyword10",
-              "keywordId": "keywordId10"
+               "role": "role0",
+               "party": [
+                  {
+                     "contactId": "individualId0"
+                  }
+               ]
             },
             {
-              "keyword": "keyword11"
+               "role": "role1",
+               "party": [
+                  {
+                     "contactId": "individualId0"
+                  }
+               ]
             }
-          ],
-          "keywordType": "keywordType1",
-          "thesaurus": {
-            "title": "title"
-          }
-        }
-      ],
-      "resourceUsage": [
-        {
-          "specificUsage": "specificUsage0",
-          "userDeterminedLimitation": "userDeterminedLimitation",
-          "limitationResponse": [
-            "limitationResponse0",
-            "limitationResponse1"
-          ]
-        },
-        {
-          "specificUsage": "specificUsage1",
-          "userDeterminedLimitation": "userDeterminedLimitation",
-          "limitationResponse": [
-            "limitationResponse0",
-            "limitationResponse1"
-          ]
-        }
-      ],
-      "constraint": [
-        {
-          "type": "use",
-          "useLimitation": [
-            "useLimitation0",
-            "useLimitation1"
-          ]
-        },
-        {
-          "type": "legal",
-          "legal": {
-            "useConstraint": [
-              "useConstraint0",
-              "useConstraint1"
+         ],
+         "spatialReferenceSystem": [
+            {
+               "referenceSystemType": "referenceSystemType0"
+            },
+            {
+               "referenceSystemType": "referenceSystemType1"
+            }
+         ],
+         "spatialRepresentationType": [
+            "spatialRepresentationType0",
+            "spatialRepresentationType1"
+         ],
+         "spatialRepresentation": [
+            {
+               "gridRepresentation": {
+                  "numberOfDimensions": 9,
+                  "dimension": [
+                     {
+                        "dimensionType": "dimensionType",
+                        "dimensionSize": 9
+                     },
+                     {
+                        "dimensionType": "dimensionType",
+                        "dimensionSize": 9
+                     }
+                  ],
+                  "cellGeometry": "cellGeometry",
+                  "transformationParameterAvailable": true
+               }
+            },
+            {
+               "vectorRepresentation": {
+                  "topologyLevel": "topologyLevel",
+                  "vectorObject": [
+                     {
+                        "objectType": "objectType",
+                        "objectCount": 9
+                     }
+                  ]
+               }
+            }
+         ],
+         "spatialResolution": [
+            {
+               "scaleFactor": 25000
+            },
+            {
+               "levelOfDetail": "levelOfDetail"
+            }
+         ],
+         "temporalResolution": [
+            {
+               "years": 1,
+               "months": 8
+            },
+            {
+               "seconds": 1
+            }
+         ],
+         "extent": [
+            {
+               "description": "description0"
+            },
+            {
+               "description": "description1"
+            }
+         ],
+         "coverageDescription": [
+            {
+               "coverageName": "coverageName0",
+               "coverageDescription": "coverageDescription0"
+            },
+            {
+               "coverageName": "coverageName1",
+               "coverageDescription": "coverageDescription1"
+            }
+         ],
+         "taxonomy": {
+            "taxonomicSystem": [
+               {
+                  "citation": {
+                     "title": "title"
+                  },
+                  "modification": "modification"
+               }
             ],
-            "accessConstraint": [
-              "accessConstraint0",
-              "accessConstraint1"
+            "identificationReference": [
+               {
+                  "identifier": "identifier0",
+                  "namespace": "namespace0",
+                  "version": "version0",
+                  "description": "description0",
+                  "authority": {
+                     "title": "title0"
+                  }
+               },
+               {
+                  "identifier": "identifier1",
+                  "namespace": "namespace1",
+                  "version": "version1",
+                  "description": "description1",
+                  "authority": {
+                     "title": "title1"
+                  }
+               }
             ],
-            "otherConstraint": [
-              "otherConstraint0",
-              "otherConstraint1"
-            ]
-          }
-        }
-      ],
-      "defaultResourceLocale": {
-        "language": "LanguageCode",
-        "country": "CountryCode",
-        "characterSet": "MD_CharacterSetCode"
-      },
-      "otherResourceLocale": [
-        {
-          "language": "LanguageCode0",
-          "country": "CountryCode0",
-          "characterSet": "MD_CharacterSetCode0"
-        },
-        {
-          "language": "LanguageCode1",
-          "country": "CountryCode1",
-          "characterSet": "MD_CharacterSetCode1"
-        }
-      ],
-      "resourceMaintenance": [
-        {
-          "frequency": "frequency0"
-        },
-        {
-          "frequency": "frequency1"
-        }
-      ],
-      "environmentDescription": "environmentDescription",
-      "supplementalInfo": "supplementalInfo"
-    }
-  ]
-
+            "identificationProcedure": "identificationProcedure",
+            "taxonomicClassification": {
+               "taxonomicRank": "taxonomicRank",
+               "latinName": "latinName"
+            }
+         },
+         "graphicOverview": [
+            {
+               "fileName": "fileName0"
+            },
+            {
+               "fileName": "fileName1"
+            }
+         ],
+         "resourceFormat": [
+            {
+               "formatSpecification": {
+                  "title": "title0"
+               }
+            },
+            {
+               "formatSpecification": {
+                  "title": "title1"
+               }
+            }
+         ],
+         "keyword": [
+            {
+               "keyword": [
+                  {
+                     "keyword": "keyword00",
+                     "keywordId": "keywordId00"
+                  },
+                  {
+                     "keyword": "keyword01"
+                  }
+               ],
+               "keywordType": "keywordType0",
+               "thesaurus": {
+                  "title": "title"
+               }
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "keyword10",
+                     "keywordId": "keywordId10"
+                  },
+                  {
+                     "keyword": "keyword11"
+                  }
+               ],
+               "keywordType": "keywordType1",
+               "thesaurus": {
+                  "title": "title"
+               }
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "oceans",
+                     "keywordId": "014"
+                  },
+                  {
+                     "keyword": "extraTerrestrial",
+                     "keywordId": "020"
+                  }
+               ],
+               "keywordType": "isoTopicCategory",
+               "thesaurus": {
+                  "title": "title"
+               }
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "structure",
+                     "keywordId": "017"
+                  }
+               ],
+               "keywordType": "isoTopicCategory",
+               "thesaurus": {
+                  "title": "title"
+               }
+            }
+         ],
+         "resourceUsage": [
+            {
+               "specificUsage": "specificUsage0",
+               "userDeterminedLimitation": "userDeterminedLimitation",
+               "limitationResponse": [
+                  "limitationResponse0",
+                  "limitationResponse1"
+               ]
+            },
+            {
+               "specificUsage": "specificUsage1",
+               "userDeterminedLimitation": "userDeterminedLimitation",
+               "limitationResponse": [
+                  "limitationResponse0",
+                  "limitationResponse1"
+               ]
+            }
+         ],
+         "constraint": [
+            {
+               "type": "use",
+               "useLimitation": [
+                  "useLimitation0",
+                  "useLimitation1"
+               ]
+            },
+            {
+               "type": "legal",
+               "legal": {
+                  "useConstraint": [
+                     "useConstraint0",
+                     "useConstraint1"
+                  ],
+                  "accessConstraint": [
+                     "accessConstraint0",
+                     "accessConstraint1"
+                  ],
+                  "otherConstraint": [
+                     "otherConstraint0",
+                     "otherConstraint1"
+                  ]
+               }
+            }
+         ],
+         "defaultResourceLocale": {
+            "language": "LanguageCode",
+            "country": "CountryCode",
+            "characterSet": "MD_CharacterSetCode"
+         },
+         "otherResourceLocale": [
+            {
+               "language": "LanguageCode0",
+               "country": "CountryCode0",
+               "characterSet": "MD_CharacterSetCode0"
+            },
+            {
+               "language": "LanguageCode1",
+               "country": "CountryCode1",
+               "characterSet": "MD_CharacterSetCode1"
+            }
+         ],
+         "resourceMaintenance": [
+            {
+               "frequency": "frequency0"
+            },
+            {
+               "frequency": "frequency1"
+            }
+         ],
+         "environmentDescription": "environmentDescription",
+         "supplementalInfo": "supplementalInfo"
+      }
+   ]
 }

--- a/test/writers/iso19115-2/resultXML/19115_2_dataIdentification.xml
+++ b/test/writers/iso19115-2/resultXML/19115_2_dataIdentification.xml
@@ -422,10 +422,7 @@
       <gmd:characterSet>
         <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="MD_CharacterSetCode1" codeSpace="userCode"/>
       </gmd:characterSet>
-      <gmd:topicCategory>
-      </gmd:topicCategory>
-      <gmd:topicCategory>
-      </gmd:topicCategory>
+      <gmd:topicCategory/>
       <gmd:environmentDescription>
         <gco:CharacterString>environmentDescription</gco:CharacterString>
       </gmd:environmentDescription>

--- a/test/writers/iso19115-2/resultXML/19115_2_keyword.xml
+++ b/test/writers/iso19115-2/resultXML/19115_2_keyword.xml
@@ -88,4 +88,75 @@
     </gmd:MD_Keywords>
   </gmd:descriptiveKeywords>
 
+  <gmd:descriptiveKeywords>
+    <gmd:MD_Keywords>
+      <gmd:keyword>
+        <gco:CharacterString>oceans</gco:CharacterString>
+      </gmd:keyword>
+      <gmd:keyword>
+        <gco:CharacterString>economy</gco:CharacterString>
+      </gmd:keyword>
+      <gmd:type>
+        <gmd:MD_KeywordTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_KeywordTypeCode" codeListValue="isoTopicCategory" codeSpace="adiwg002"/>
+      </gmd:type>
+      <gmd:thesaurusName>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>title</gco:CharacterString>
+          </gmd:title>
+          <gmd:alternateTitle/>
+          <gmd:date gco:nilReason="missing"/>
+          <gmd:edition/>
+          <gmd:identifier/>
+          <gmd:citedResponsibleParty/>
+          <gmd:presentationForm/>
+          <gmd:series/>
+          <gmd:otherCitationDetails/>
+          <gmd:ISBN/>
+          <gmd:ISSN/>
+        </gmd:CI_Citation>
+      </gmd:thesaurusName>
+    </gmd:MD_Keywords>
+  </gmd:descriptiveKeywords>
+
+  <gmd:descriptiveKeywords>
+    <gmd:MD_Keywords>
+      <gmd:keyword>
+        <gco:CharacterString>structure</gco:CharacterString>
+      </gmd:keyword>
+      <gmd:type>
+        <gmd:MD_KeywordTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_KeywordTypeCode" codeListValue="isoTopicCategory" codeSpace="adiwg002"/>
+      </gmd:type>
+      <gmd:thesaurusName>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>title</gco:CharacterString>
+          </gmd:title>
+          <gmd:alternateTitle/>
+          <gmd:date gco:nilReason="missing"/>
+          <gmd:edition/>
+          <gmd:identifier/>
+          <gmd:citedResponsibleParty/>
+          <gmd:presentationForm/>
+          <gmd:series/>
+          <gmd:otherCitationDetails/>
+          <gmd:ISBN/>
+          <gmd:ISSN/>
+        </gmd:CI_Citation>
+      </gmd:thesaurusName>
+    </gmd:MD_Keywords>
+  </gmd:descriptiveKeywords>
+
+  <gmd:topicCategory>
+    <gmd:MD_TopicCategoryCode>oceans</gmd:MD_TopicCategoryCode>
+  </gmd:topicCategory>
+
+  <gmd:topicCategory>
+    <gmd:MD_TopicCategoryCode>economy</gmd:MD_TopicCategoryCode>
+  </gmd:topicCategory>
+
+  <gmd:topicCategory>
+    <gmd:MD_TopicCategoryCode>structure</gmd:MD_TopicCategoryCode>
+  </gmd:topicCategory>
+
 </gmi:MI_Metadata>

--- a/test/writers/iso19115-2/tc_19115_2_dataIdentification.rb
+++ b/test/writers/iso19115-2/tc_19115_2_dataIdentification.rb
@@ -12,32 +12,32 @@ include REXML
 
 class TestWriter191152DataIdentification < MiniTest::Test
 
-    # read the ISO 19115-2 reference file
-    fname = File.join(File.dirname(__FILE__), 'resultXML', '19115_2_dataIdentification.xml')
-    file = File.new(fname)
-    iso_xml = Document.new(file)
-    @@aRefXML = []
-    XPath.each(iso_xml, '//gmd:identificationInfo') {|e| @@aRefXML << e}
+   # read the ISO 19115-2 reference file
+   fname = File.join(File.dirname(__FILE__), 'resultXML', '19115_2_dataIdentification.xml')
+   file = File.new(fname)
+   iso_xml = Document.new(file)
+   @@aRefXML = []
+   XPath.each(iso_xml, '//gmd:identificationInfo') {|e| @@aRefXML << e}
 
-    # read the mdJson 2.0 file
-    fname = File.join(File.dirname(__FILE__), 'testData', '19115_2_dataIdentification.json')
-    file = File.open(fname, 'r')
-    @@mdJson = file.read
-    file.close
+   # read the mdJson 2.0 file
+   fname = File.join(File.dirname(__FILE__), 'testData', '19115_2_dataIdentification.json')
+   file = File.open(fname, 'r')
+   @@mdJson = file.read
+   file.close
 
-    def test_19115_2_dataIdentification
+   def test_19115_2_dataIdentification
 
-        hResponseObj = ADIWG::Mdtranslator.translate(
-            file: @@mdJson, reader: 'mdJson', writer: 'iso19115_2', showAllTags: true
-        )
+      hResponseObj = ADIWG::Mdtranslator.translate(
+         file: @@mdJson, reader: 'mdJson', writer: 'iso19115_2', showAllTags: true
+      )
 
-        metadata = hResponseObj[:writerOutput]
-        iso_out = Document.new(metadata)
+      metadata = hResponseObj[:writerOutput]
+      iso_out = Document.new(metadata)
 
-        checkXML = XPath.first(iso_out, '//gmd:identificationInfo')
+      checkXML = XPath.first(iso_out, '//gmd:identificationInfo')
 
-        assert_equal @@aRefXML[0].to_s.squeeze, checkXML.to_s.squeeze
+      assert_equal @@aRefXML[0].to_s.squeeze, checkXML.to_s.squeeze
 
-    end
+   end
 
 end

--- a/test/writers/iso19115-2/tc_19115_2_keyword.rb
+++ b/test/writers/iso19115-2/tc_19115_2_keyword.rb
@@ -1,8 +1,9 @@
 # MdTranslator - minitest of
-# writers / iso19115_2 / class_keywrod
+# writers / iso19115_2 / class_keyword
 
 # History:
-#   Stan Smith 2017-01-04 original script
+#  Stan Smith 2017-05-16 added isoTopicCategory to keyword
+#  Stan Smith 2017-01-04 original script
 
 require 'minitest/autorun'
 require 'json'
@@ -12,36 +13,57 @@ include REXML
 
 class TestWriter191152Keyword < MiniTest::Test
 
-    # read the ISO 19115-2 reference file
-    fname = File.join(File.dirname(__FILE__), 'resultXML', '19115_2_keyword.xml')
-    file = File.new(fname)
-    @@iso_xml = Document.new(file)
+   # read the ISO 19115-2 reference file
+   fname = File.join(File.dirname(__FILE__), 'resultXML', '19115_2_keyword.xml')
+   file = File.new(fname)
+   @@iso_xml = Document.new(file)
 
-    # read the mdJson 2.0 file
-    fname = File.join(File.dirname(__FILE__), 'testData', '19115_2_keyword.json')
-    file = File.open(fname, 'r')
-    @@mdJson = file.read
-    file.close
+   # read the mdJson 2.0 file
+   fname = File.join(File.dirname(__FILE__), 'testData', '19115_2_keyword.json')
+   file = File.open(fname, 'r')
+   @@mdJson = file.read
+   file.close
 
-    def test_19115_2_keyword
+   def test_19115_2_keyword
 
-        aRefXML = []
-        XPath.each(@@iso_xml, '//gmd:descriptiveKeywords') {|e| aRefXML << e}
+      aRefXML = []
+      XPath.each(@@iso_xml, '//gmd:descriptiveKeywords') {|e| aRefXML << e}
 
-        hResponseObj = ADIWG::Mdtranslator.translate(
-            file: @@mdJson, reader: 'mdJson', writer: 'iso19115_2', showAllTags: true
-        )
+      hResponseObj = ADIWG::Mdtranslator.translate(
+         file: @@mdJson, reader: 'mdJson', writer: 'iso19115_2', showAllTags: true
+      )
 
-        metadata = hResponseObj[:writerOutput]
-        iso_out = Document.new(metadata)
+      metadata = hResponseObj[:writerOutput]
+      iso_out = Document.new(metadata)
 
-        aCheckXML = []
-        XPath.each(iso_out, '//gmd:descriptiveKeywords') {|e| aCheckXML << e}
+      aCheckXML = []
+      XPath.each(iso_out, '//gmd:descriptiveKeywords') {|e| aCheckXML << e}
 
-        aRefXML.length.times{|i|
-            assert_equal aRefXML[i].to_s.squeeze, aCheckXML[i].to_s.squeeze
-        }
+      aRefXML.length.times {|i|
+         assert_equal aRefXML[i].to_s.squeeze, aCheckXML[i].to_s.squeeze
+      }
 
-    end
+   end
+
+   def test_19115_2_topicCategory
+
+      aRefXML = []
+      XPath.each(@@iso_xml, '//gmd:topicCategory') {|e| aRefXML << e}
+
+      hResponseObj = ADIWG::Mdtranslator.translate(
+         file: @@mdJson, reader: 'mdJson', writer: 'iso19115_2', showAllTags: true
+      )
+
+      metadata = hResponseObj[:writerOutput]
+      iso_out = Document.new(metadata)
+
+      aCheckXML = []
+      XPath.each(iso_out, '//gmd:topicCategory') {|e| aCheckXML << e}
+
+      aRefXML.length.times {|i|
+         assert_equal aRefXML[i].to_s.squeeze, aCheckXML[i].to_s.squeeze
+      }
+
+   end
 
 end

--- a/test/writers/iso19115-2/testData/19115_2_dataIdentification.json
+++ b/test/writers/iso19115-2/testData/19115_2_dataIdentification.json
@@ -50,10 +50,6 @@
         "status0",
         "status1"
       ],
-      "topicCategory": [
-        "topicCategory0",
-        "topicCategory1"
-      ],
       "pointOfContact": [
         {
           "role": "role0",

--- a/test/writers/iso19115-2/testData/19115_2_keyword.json
+++ b/test/writers/iso19115-2/testData/19115_2_keyword.json
@@ -1,93 +1,123 @@
 {
-  "schema": {
-    "name": "mdJson",
-    "version": "2.0.0"
-  },
-  "contact": [
-    {
-      "contactId": "CID001",
-      "isOrganization": false,
-      "name": "contact - minimal"
-    }
-  ],
-  "metadata": {
-    "metadataInfo": {
-      "metadataContact": [
-        {
-          "role": "metadataContact",
-          "party": [
+   "schema": {
+      "name": "mdJson",
+      "version": "2.0.0"
+   },
+   "contact": [
+      {
+         "contactId": "CID001",
+         "isOrganization": false,
+         "name": "contact - minimal"
+      }
+   ],
+   "metadata": {
+      "metadataInfo": {
+         "metadataContact": [
             {
-              "contactId": "CID001"
+               "role": "metadataContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
             }
-          ]
-        }
-      ]
-    },
-    "resourceInfo": {
-      "resourceType": [
-        {
-          "type": "type",
-          "name": "name"
-        }
-      ],
-      "citation": {
-        "title": "title"
+         ]
       },
-      "abstract": "abstract",
-      "status": ["status"],
-      "pointOfContact": [
-        {
-          "role": "pointOfContact",
-          "party": [
+      "resourceInfo": {
+         "resourceType": [
             {
-              "contactId": "CID001"
+               "type": "type",
+               "name": "name"
             }
-          ]
-        }
-      ],
-      "defaultResourceLocale": {
-        "language": "eng",
-        "country": "USA",
-        "characterSet": "UTF-8"
-      },
-      "keyword": [
-        {
-          "keyword": [
+         ],
+         "citation": {
+            "title": "title"
+         },
+         "abstract": "abstract",
+         "status": [
+            "status"
+         ],
+         "pointOfContact": [
             {
-              "keyword": "keyword00",
-              "keywordId": "keywordId00"
-            },
-            {
-              "keyword": "keyword01"
-            },
-            {
-              "keyword": "keyword02, keyword03, keyword04"
-            },
-            {
-              "keyword": "keyword05 and keyword06"
-            },
-            {
-              "keyword": "keyword07 > keyword08 > keyword09"
+               "role": "pointOfContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
             }
-          ],
-          "keywordType": "keywordType0",
-          "thesaurus": {
-            "title": "title0"
-          }
-        },
-        {
-          "keyword": [
+         ],
+         "defaultResourceLocale": {
+            "language": "eng",
+            "country": "USA",
+            "characterSet": "UTF-8"
+         },
+         "keyword": [
             {
-              "keyword": "keyword10",
-              "keywordId": "keywordId10"
+               "keyword": [
+                  {
+                     "keyword": "keyword00",
+                     "keywordId": "keywordId00"
+                  },
+                  {
+                     "keyword": "keyword01"
+                  },
+                  {
+                     "keyword": "keyword02, keyword03, keyword04"
+                  },
+                  {
+                     "keyword": "keyword05 and keyword06"
+                  },
+                  {
+                     "keyword": "keyword07 > keyword08 > keyword09"
+                  }
+               ],
+               "keywordType": "keywordType0",
+               "thesaurus": {
+                  "title": "title0"
+               }
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "keyword10",
+                     "keywordId": "keywordId10"
+                  }
+               ],
+               "keywordType": "keywordType1",
+               "thesaurus": {
+                  "title": "title1"
+               }
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "oceans",
+                     "keywordId": "014"
+                  },
+                  {
+                     "keyword": "economy",
+                     "keywordId": "005"
+                  }
+               ],
+               "keywordType": "isoTopicCategory",
+               "thesaurus": {
+                  "title": "title"
+               }
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "structure",
+                     "keywordId": "017"
+                  }
+               ],
+               "keywordType": "isoTopicCategory",
+               "thesaurus": {
+                  "title": "title"
+               }
             }
-          ],
-          "keywordType": "keywordType1",
-          "thesaurus": {
-            "title": "title1"
-          }
-        }
-      ]
-    }
-  }
+         ]
+      }
+   }
 }

--- a/test/writers/mdJson/tc_mdjson_additionalDocumentation.rb
+++ b/test/writers/mdJson/tc_mdjson_additionalDocumentation.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterAdditionalDocumentation < TestWriterMdJsonParent
+class TestWriterMdJsonAdditionalDocumentation < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('additionalDocumentation.json')

--- a/test/writers/mdJson/tc_mdjson_address.rb
+++ b/test/writers/mdJson/tc_mdjson_address.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterAddress < TestWriterMdJsonParent
+class TestWriterMdJsonAddress < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('address.json')

--- a/test/writers/mdJson/tc_mdjson_allocation.rb
+++ b/test/writers/mdJson/tc_mdjson_allocation.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterAllocation < TestWriterMdJsonParent
+class TestWriterMdJsonAllocation < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('allocation.json')

--- a/test/writers/mdJson/tc_mdjson_associatedResource.rb
+++ b/test/writers/mdJson/tc_mdjson_associatedResource.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterAssociatedResource < TestWriterMdJsonParent
+class TestWriterMdJsonAssociatedResource < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('associatedResource.json')

--- a/test/writers/mdJson/tc_mdjson_attribute.rb
+++ b/test/writers/mdJson/tc_mdjson_attribute.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterAttribute < TestWriterMdJsonParent
+class TestWriterMdJsonAttribute < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('attribute.json')

--- a/test/writers/mdJson/tc_mdjson_attributeGroup.rb
+++ b/test/writers/mdJson/tc_mdjson_attributeGroup.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterAttributeGroup < TestWriterMdJsonParent
+class TestWriterMdJsonAttributeGroup < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('attributeGroup.json')

--- a/test/writers/mdJson/tc_mdjson_boundingBox.rb
+++ b/test/writers/mdJson/tc_mdjson_boundingBox.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterBoundingBox < TestWriterMdJsonParent
+class TestWriterMdJsonBoundingBox < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('geographicExtent.json')

--- a/test/writers/mdJson/tc_mdjson_citation.rb
+++ b/test/writers/mdJson/tc_mdjson_citation.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterCitation < TestWriterMdJsonParent
+class TestWriterMdJsonCitation < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('citation.json')

--- a/test/writers/mdJson/tc_mdjson_constraint.rb
+++ b/test/writers/mdJson/tc_mdjson_constraint.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterConstraint < TestWriterMdJsonParent
+class TestWriterMdJsonConstraint < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('constraint.json')

--- a/test/writers/mdJson/tc_mdjson_contact.rb
+++ b/test/writers/mdJson/tc_mdjson_contact.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterContact < TestWriterMdJsonParent
+class TestWriterMdJsonContact < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('contact.json')

--- a/test/writers/mdJson/tc_mdjson_coverage.rb
+++ b/test/writers/mdJson/tc_mdjson_coverage.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterCoverageDescription < TestWriterMdJsonParent
+class TestWriterMdJsonCoverageDescription < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('coverage.json')

--- a/test/writers/mdJson/tc_mdjson_date.rb
+++ b/test/writers/mdJson/tc_mdjson_date.rb
@@ -14,7 +14,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDateTime < TestWriterMdJsonParent
+class TestWriterMdJsonDateTime < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('date.json')

--- a/test/writers/mdJson/tc_mdjson_dictionary.rb
+++ b/test/writers/mdJson/tc_mdjson_dictionary.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDictionary < TestWriterMdJsonParent
+class TestWriterMdJsonDictionary < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('dictionary.json')

--- a/test/writers/mdJson/tc_mdjson_dimension.rb
+++ b/test/writers/mdJson/tc_mdjson_dimension.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDimension < TestWriterMdJsonParent
+class TestWriterMdJsonDimension < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('dimension.json')

--- a/test/writers/mdJson/tc_mdjson_distributionInfo.rb
+++ b/test/writers/mdJson/tc_mdjson_distributionInfo.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDistributionInfo < TestWriterMdJsonParent
+class TestWriterMdJsonDistributionInfo < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('distribution.json')

--- a/test/writers/mdJson/tc_mdjson_distributor.rb
+++ b/test/writers/mdJson/tc_mdjson_distributor.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDistributor < TestWriterMdJsonParent
+class TestWriterMdJsonDistributor < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('distributor.json')

--- a/test/writers/mdJson/tc_mdjson_domain.rb
+++ b/test/writers/mdJson/tc_mdjson_domain.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDomain < TestWriterMdJsonParent
+class TestWriterMdJsonDomain < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('domain.json')

--- a/test/writers/mdJson/tc_mdjson_duration.rb
+++ b/test/writers/mdJson/tc_mdjson_duration.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterDuration < TestWriterMdJsonParent
+class TestWriterMdJsonDuration < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('duration.json')

--- a/test/writers/mdJson/tc_mdjson_entity.rb
+++ b/test/writers/mdJson/tc_mdjson_entity.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterEntity < TestWriterMdJsonParent
+class TestWriterMdJsonEntity < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('entity.json')

--- a/test/writers/mdJson/tc_mdjson_entityAttribute.rb
+++ b/test/writers/mdJson/tc_mdjson_entityAttribute.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterEntityAttribute < TestWriterMdJsonParent
+class TestWriterMdJsonEntityAttribute < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('entityAttribute.json')

--- a/test/writers/mdJson/tc_mdjson_entityForeignKey.rb
+++ b/test/writers/mdJson/tc_mdjson_entityForeignKey.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterEntityForeignKey < TestWriterMdJsonParent
+class TestWriterMdJsonEntityForeignKey < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('entityForeignKey.json')

--- a/test/writers/mdJson/tc_mdjson_entityIndex.rb
+++ b/test/writers/mdJson/tc_mdjson_entityIndex.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterEntityIndex < TestWriterMdJsonParent
+class TestWriterMdJsonEntityIndex < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('entityIndex.json')

--- a/test/writers/mdJson/tc_mdjson_extent.rb
+++ b/test/writers/mdJson/tc_mdjson_extent.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterExtent < TestWriterMdJsonParent
+class TestWriterMdJsonExtent < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('extent.json')

--- a/test/writers/mdJson/tc_mdjson_format.rb
+++ b/test/writers/mdJson/tc_mdjson_format.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterFormat < TestWriterMdJsonParent
+class TestWriterMdJsonFormat < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('format.json')

--- a/test/writers/mdJson/tc_mdjson_funding.rb
+++ b/test/writers/mdJson/tc_mdjson_funding.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterFunding < TestWriterMdJsonParent
+class TestWriterMdJsonFunding < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('funding.json')

--- a/test/writers/mdJson/tc_mdjson_geographicExtent.rb
+++ b/test/writers/mdJson/tc_mdjson_geographicExtent.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterGeographicExtent < TestWriterMdJsonParent
+class TestWriterMdJsonGeographicExtent < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('geographicExtent.json')

--- a/test/writers/mdJson/tc_mdjson_georectified.rb
+++ b/test/writers/mdJson/tc_mdjson_georectified.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterGeorectified < TestWriterMdJsonParent
+class TestWriterMdJsonGeorectified < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('georectified.json')

--- a/test/writers/mdJson/tc_mdjson_georeferenceable.rb
+++ b/test/writers/mdJson/tc_mdjson_georeferenceable.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterGeoreferenceable < TestWriterMdJsonParent
+class TestWriterMdJsonGeoreferenceable < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('georeferenceable.json')

--- a/test/writers/mdJson/tc_mdjson_graphic.rb
+++ b/test/writers/mdJson/tc_mdjson_graphic.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterGraphicOverview < TestWriterMdJsonParent
+class TestWriterMdJsonGraphicOverview < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('graphic.json')

--- a/test/writers/mdJson/tc_mdjson_grid.rb
+++ b/test/writers/mdJson/tc_mdjson_grid.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterGrid < TestWriterMdJsonParent
+class TestWriterMdJsonGrid < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('grid.json')

--- a/test/writers/mdJson/tc_mdjson_identifier.rb
+++ b/test/writers/mdJson/tc_mdjson_identifier.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterIdentifier < TestWriterMdJsonParent
+class TestWriterMdJsonIdentifier < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('identifier.json')

--- a/test/writers/mdJson/tc_mdjson_image.rb
+++ b/test/writers/mdJson/tc_mdjson_image.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterImageDescription < TestWriterMdJsonParent
+class TestWriterMdJsonImageDescription < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('image.json')

--- a/test/writers/mdJson/tc_mdjson_keyword.rb
+++ b/test/writers/mdJson/tc_mdjson_keyword.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterKeyword < TestWriterMdJsonParent
+class TestWriterMdJsonKeyword < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('keyword.json')

--- a/test/writers/mdJson/tc_mdjson_keywordObject.rb
+++ b/test/writers/mdJson/tc_mdjson_keywordObject.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterKeywordObject < TestWriterMdJsonParent
+class TestWriterMdJsonKeywordObject < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('keyword.json')

--- a/test/writers/mdJson/tc_mdjson_lineageInfo.rb
+++ b/test/writers/mdJson/tc_mdjson_lineageInfo.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterLineageInfo < TestWriterMdJsonParent
+class TestWriterMdJsonLineageInfo < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('lineage.json')

--- a/test/writers/mdJson/tc_mdjson_locale.rb
+++ b/test/writers/mdJson/tc_mdjson_locale.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterLocale < TestWriterMdJsonParent
+class TestWriterMdJsonLocale < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('locale.json')

--- a/test/writers/mdJson/tc_mdjson_maintenance.rb
+++ b/test/writers/mdJson/tc_mdjson_maintenance.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterMaintenance < TestWriterMdJsonParent
+class TestWriterMdJsonMaintenance < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('maintenance.json')

--- a/test/writers/mdJson/tc_mdjson_mdJson.rb
+++ b/test/writers/mdJson/tc_mdjson_mdJson.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterMdJson < TestWriterMdJsonParent
+class TestWriterMdJsonMdJson < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('mdJson.json')

--- a/test/writers/mdJson/tc_mdjson_measure.rb
+++ b/test/writers/mdJson/tc_mdjson_measure.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterMeasure < TestWriterMdJsonParent
+class TestWriterMdJsonMeasure < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('measure.json')

--- a/test/writers/mdJson/tc_mdjson_medium.rb
+++ b/test/writers/mdJson/tc_mdjson_medium.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterMedium < TestWriterMdJsonParent
+class TestWriterMdJsonMedium < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('medium.json')

--- a/test/writers/mdJson/tc_mdjson_metadata.rb
+++ b/test/writers/mdJson/tc_mdjson_metadata.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterMetadata < TestWriterMdJsonParent
+class TestWriterMdJsonMetadata < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('metadata.json')

--- a/test/writers/mdJson/tc_mdjson_metadataInfo.rb
+++ b/test/writers/mdJson/tc_mdjson_metadataInfo.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterMetadataInfo < TestWriterMdJsonParent
+class TestWriterMdJsonMetadataInfo < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('metadataInfo.json')

--- a/test/writers/mdJson/tc_mdjson_onlineResource.rb
+++ b/test/writers/mdJson/tc_mdjson_onlineResource.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterOnlineResource < TestWriterMdJsonParent
+class TestWriterMdJsonOnlineResource < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('onlineResource.json')

--- a/test/writers/mdJson/tc_mdjson_orderProcess.rb
+++ b/test/writers/mdJson/tc_mdjson_orderProcess.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterOrderProcess < TestWriterMdJsonParent
+class TestWriterMdJsonOrderProcess < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('orderProcess.json')

--- a/test/writers/mdJson/tc_mdjson_phone.rb
+++ b/test/writers/mdJson/tc_mdjson_phone.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterPhone < TestWriterMdJsonParent
+class TestWriterMdJsonPhone < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('phone.json')

--- a/test/writers/mdJson/tc_mdjson_processStep.rb
+++ b/test/writers/mdJson/tc_mdjson_processStep.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterProcessStep < TestWriterMdJsonParent
+class TestWriterMdJsonProcessStep < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('processStep.json')

--- a/test/writers/mdJson/tc_mdjson_releasability.rb
+++ b/test/writers/mdJson/tc_mdjson_releasability.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterReleasability < TestWriterMdJsonParent
+class TestWriterMdJsonReleasability < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('releasability.json')

--- a/test/writers/mdJson/tc_mdjson_resourceInfo.rb
+++ b/test/writers/mdJson/tc_mdjson_resourceInfo.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterResourceInfo < TestWriterMdJsonParent
+class TestWriterMdJsonResourceInfo < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('resourceInfo.json')
@@ -30,6 +30,10 @@ class TestWriterResourceInfo < TestWriterMdJsonParent
 
       expect = JSON.parse(@@jsonIn)
       expect = expect['metadata']['resourceInfo']
+
+      # delete deprecated element from source mdJson so it will match output from writer
+      expect.delete('topicCategory')
+
       got = JSON.parse(metadata[:writerOutput])
       got = got['metadata']['resourceInfo']
 

--- a/test/writers/mdJson/tc_mdjson_responsibleParty.rb
+++ b/test/writers/mdJson/tc_mdjson_responsibleParty.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterResponsibleParty < TestWriterMdJsonParent
+class TestWriterMdJsonResponsibleParty < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('responsibleParty.json')

--- a/test/writers/mdJson/tc_mdjson_scope.rb
+++ b/test/writers/mdJson/tc_mdjson_scope.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterScope < TestWriterMdJsonParent
+class TestWriterMdJsonScope < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('scope.json')

--- a/test/writers/mdJson/tc_mdjson_series.rb
+++ b/test/writers/mdJson/tc_mdjson_series.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterSeries < TestWriterMdJsonParent
+class TestWriterMdJsonSeries < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('series.json')

--- a/test/writers/mdJson/tc_mdjson_source.rb
+++ b/test/writers/mdJson/tc_mdjson_source.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterSource < TestWriterMdJsonParent
+class TestWriterMdJsonSource < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('source.json')

--- a/test/writers/mdJson/tc_mdjson_spatialReference.rb
+++ b/test/writers/mdJson/tc_mdjson_spatialReference.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterSpatialReference < TestWriterMdJsonParent
+class TestWriterMdJsonSpatialReference < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('spatialReference.json')

--- a/test/writers/mdJson/tc_mdjson_spatialRepresentation.rb
+++ b/test/writers/mdJson/tc_mdjson_spatialRepresentation.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterSpatialRepresentation < TestWriterMdJsonParent
+class TestWriterMdJsonSpatialRepresentation < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('spatialRepresentation.json')

--- a/test/writers/mdJson/tc_mdjson_spatialResolution.rb
+++ b/test/writers/mdJson/tc_mdjson_spatialResolution.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterSpatialResolution < TestWriterMdJsonParent
+class TestWriterMdJsonSpatialResolution < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('spatialResolution.json')

--- a/test/writers/mdJson/tc_mdjson_taxonomicClassification.rb
+++ b/test/writers/mdJson/tc_mdjson_taxonomicClassification.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTaxonomicClassification < TestWriterMdJsonParent
+class TestWriterMdJsonTaxonomicClassification < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('taxonomicClassification.json')

--- a/test/writers/mdJson/tc_mdjson_taxonomicSystem.rb
+++ b/test/writers/mdJson/tc_mdjson_taxonomicSystem.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTaxonomicSystem < TestWriterMdJsonParent
+class TestWriterMdJsonTaxonomicSystem < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('taxonomicSystem.json')

--- a/test/writers/mdJson/tc_mdjson_taxonomy.rb
+++ b/test/writers/mdJson/tc_mdjson_taxonomy.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTaxonomy < TestWriterMdJsonParent
+class TestWriterMdJsonTaxonomy < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('taxonomy.json')

--- a/test/writers/mdJson/tc_mdjson_temporalExtent.rb
+++ b/test/writers/mdJson/tc_mdjson_temporalExtent.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTemporalExtent < TestWriterMdJsonParent
+class TestWriterMdJsonTemporalExtent < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('temporalExtent.json')

--- a/test/writers/mdJson/tc_mdjson_timeInstant.rb
+++ b/test/writers/mdJson/tc_mdjson_timeInstant.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTimeInstant < TestWriterMdJsonParent
+class TestWriterMdJsonTimeInstant < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('timeInstant.json')

--- a/test/writers/mdJson/tc_mdjson_timePeriod.rb
+++ b/test/writers/mdJson/tc_mdjson_timePeriod.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTimePeriod < TestWriterMdJsonParent
+class TestWriterMdJsonTimePeriod < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('timePeriod.json')

--- a/test/writers/mdJson/tc_mdjson_transferOption.rb
+++ b/test/writers/mdJson/tc_mdjson_transferOption.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterTransferOption < TestWriterMdJsonParent
+class TestWriterMdJsonTransferOption < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('transferOption.json')

--- a/test/writers/mdJson/tc_mdjson_usage.rb
+++ b/test/writers/mdJson/tc_mdjson_usage.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterResourceUsage < TestWriterMdJsonParent
+class TestWriterMdJsonResourceUsage < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('usage.json')

--- a/test/writers/mdJson/tc_mdjson_vector.rb
+++ b/test/writers/mdJson/tc_mdjson_vector.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterVector < TestWriterMdJsonParent
+class TestWriterMdJsonVector < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('vector.json')

--- a/test/writers/mdJson/tc_mdjson_vectorObject.rb
+++ b/test/writers/mdJson/tc_mdjson_vectorObject.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterVectorObject < TestWriterMdJsonParent
+class TestWriterMdJsonVectorObject < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('vectorObject.json')

--- a/test/writers/mdJson/tc_mdjson_verticalExtent.rb
+++ b/test/writers/mdJson/tc_mdjson_verticalExtent.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterVerticalExtent < TestWriterMdJsonParent
+class TestWriterMdJsonVerticalExtent < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('verticalExtent.json')

--- a/test/writers/mdJson/tc_mdjson_voucher.rb
+++ b/test/writers/mdJson/tc_mdjson_voucher.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'mdjson_test_parent'
 
-class TestWriterVoucher < TestWriterMdJsonParent
+class TestWriterMdJsonVoucher < TestWriterMdJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterMdJsonParent.getJson('voucher.json')

--- a/test/writers/mdJson/testData/keyword.json
+++ b/test/writers/mdJson/testData/keyword.json
@@ -82,6 +82,22 @@
                      "keyword": "keyword12"
                   }
                ]
+            },
+            {
+               "keyword": [
+                  {
+                     "keyword": "environment",
+                     "keywordId": "007"
+                  },
+                  {
+                     "keyword": "inlandWaters",
+                     "keywordId": "012"
+                  }
+               ],
+               "keywordType": "isoTopicCategory",
+               "thesaurus": {
+                  "title": "ISO Topic Categories"
+               }
             }
          ]
       }

--- a/test/writers/mdJson/testData/resourceInfo.json
+++ b/test/writers/mdJson/testData/resourceInfo.json
@@ -52,10 +52,7 @@
             "status0",
             "status1"
          ],
-         "topicCategory": [
-            "topicCategory0",
-            "topicCategory1"
-         ],
+         "topicCategory": [],
          "pointOfContact": [
             {
                "role": "role0",

--- a/test/writers/sbJson/sbjson_test_parent.rb
+++ b/test/writers/sbJson/sbjson_test_parent.rb
@@ -1,0 +1,63 @@
+# MdTranslator - minitest of
+# parent class for all tc_sbjson tests
+
+# History:
+# Stan Smith 2017-05-12 original script
+
+require 'minitest/autorun'
+require 'json'
+require 'json-schema'
+
+class TestWriterSbJsonParent < MiniTest::Test
+
+   # get json file for tests from examples folder
+   def self.getJson(fileName)
+
+      file = File.join(File.dirname(__FILE__), 'testData', fileName)
+      file = File.open(file, 'r')
+      jsonFile = file.read
+      file.close
+      return jsonFile
+
+   end
+
+end
+
+class Hash
+   def deep_diff(other)
+      (self.keys + other.keys).uniq.inject({}) do |memo, key|
+         left = self[key]
+         right = other[key]
+
+         next memo if left == right
+
+         if left.respond_to?(:deep_diff) && right.respond_to?(:deep_diff)
+            memo[key] = left.deep_diff(right)
+         else
+            memo[key] = [left, right]
+         end
+
+         memo
+      end
+   end
+end
+
+class Array
+   def deep_diff(array)
+      largest = [self.count, array.count].max
+      memo = {}
+
+      0.upto(largest - 1) do |index|
+         left = self[index]
+         right = array[index]
+
+         next if left == right
+
+         if left.respond_to?(:deep_diff) && right.respond_to?(:deep_diff)
+            memo[index] = left.deep_diff(right)
+         else
+            memo[index] = [left, right]
+         end
+      end
+   end
+end

--- a/test/writers/sbJson/tc_sbjson_body.rb
+++ b/test/writers/sbJson/tc_sbjson_body.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'sbjson_test_parent'
 
-class TestWriterTitle < TestWriterSbJsonParent
+class TestWriterBody < TestWriterSbJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterSbJsonParent.getJson('body.json')

--- a/test/writers/sbJson/tc_sbjson_body.rb
+++ b/test/writers/sbJson/tc_sbjson_body.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'sbjson_test_parent'
 
-class TestWriterBody < TestWriterSbJsonParent
+class TestWriterSbJsonBody < TestWriterSbJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterSbJsonParent.getJson('body.json')

--- a/test/writers/sbJson/tc_sbjson_body.rb
+++ b/test/writers/sbJson/tc_sbjson_body.rb
@@ -1,0 +1,44 @@
+# sbJson 1 writer tests - body/summary
+
+# History:
+#  Stan Smith 2017-05-16 original script
+
+require 'minitest/autorun'
+require 'json'
+require 'adiwg-mdtranslator'
+require_relative 'sbjson_test_parent'
+
+class TestWriterTitle < TestWriterSbJsonParent
+
+   # get input JSON for test
+   @@jsonIn = TestWriterSbJsonParent.getJson('body.json')
+
+   def test_body
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['body']
+
+      assert_equal 'myBody', got
+
+   end
+
+   def test_summary
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['summary']
+
+      assert_equal 'mySummary', got
+
+   end
+
+end
+
+

--- a/test/writers/sbJson/tc_sbjson_citation.rb
+++ b/test/writers/sbJson/tc_sbjson_citation.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'sbjson_test_parent'
 
-class TestWriterCitation < TestWriterSbJsonParent
+class TestWriterSbJsonCitation < TestWriterSbJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterSbJsonParent.getJson('citation.json')
@@ -22,7 +22,6 @@ class TestWriterCitation < TestWriterSbJsonParent
       expect = 'Person 001, Person 002, Organization 001, Person 003, Person 004, 2017-05(creation), 2017-05-16(publish), 2017-05-16T16:10:00-09:00(revision), myCitationTitle, http://ISO.uri/adiwg/0, http://ISO.uri/adiwg/1'
       hJsonOut = JSON.parse(metadata[:writerOutput])
       got = hJsonOut['citation']
-      File.write('/mnt/hgfs/ShareDrive/writeOut.json', hJsonOut)
 
       assert_equal expect, got
 

--- a/test/writers/sbJson/tc_sbjson_citation.rb
+++ b/test/writers/sbJson/tc_sbjson_citation.rb
@@ -1,0 +1,33 @@
+# sbJson 1 writer tests - citation
+
+# History:
+#  Stan Smith 2017-05-16 original script
+
+require 'minitest/autorun'
+require 'json'
+require 'adiwg-mdtranslator'
+require_relative 'sbjson_test_parent'
+
+class TestWriterCitation < TestWriterSbJsonParent
+
+   # get input JSON for test
+   @@jsonIn = TestWriterSbJsonParent.getJson('citation.json')
+
+   def test_citation
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      expect = 'Person 001, Person 002, Organization 001, Person 003, Person 004, 2017-05(creation), 2017-05-16(publish), 2017-05-16T16:10:00-09:00(revision), myCitationTitle, http://ISO.uri/adiwg/0, http://ISO.uri/adiwg/1'
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['citation']
+      File.write('/mnt/hgfs/ShareDrive/writeOut.json', hJsonOut)
+
+      assert_equal expect, got
+
+   end
+
+end
+
+

--- a/test/writers/sbJson/tc_sbjson_id.rb
+++ b/test/writers/sbJson/tc_sbjson_id.rb
@@ -1,0 +1,70 @@
+# mdJson 2.0 writer tests - address
+
+# History:
+#  Stan Smith 2017-05-13 original script
+
+require 'minitest/autorun'
+require 'json'
+require 'adiwg-mdtranslator'
+require_relative 'sbjson_test_parent'
+
+class TestWriterId < TestWriterSbJsonParent
+
+   # get input JSON for test
+   @@jsonIn = TestWriterSbJsonParent.getJson('id.json')
+
+   def test_id_metadata_identifier
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['id']
+
+      File.write('/mnt/hgfs/ShareDrive/writeOut.json', metadata[:writerOutput])
+
+      assert_equal 'myMetadataIdentifier', got
+
+   end
+
+   def test_id_metadata_citation
+
+      hJsonIn = JSON.parse(@@jsonIn)
+      hJsonIn['metadata']['metadataInfo'].delete('metadataIdentifier')
+      hIn = hJsonIn.to_json
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: hIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['id']
+
+      File.write('/mnt/hgfs/ShareDrive/writeOut.json', metadata[:writerOutput])
+
+      assert_equal 'myCitationIdentifier0', got
+
+   end
+
+   def test_id_default
+
+      hJsonIn = JSON.parse(@@jsonIn)
+      hJsonIn['metadata']['metadataInfo'].delete('metadataIdentifier')
+      hJsonIn['metadata']['resourceInfo']['citation'].delete('identifier')
+      hIn = hJsonIn.to_json
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: hIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['id']
+
+      File.write('/mnt/hgfs/ShareDrive/writeOut.json', metadata[:writerOutput])
+
+      refute_nil got
+
+   end
+
+end

--- a/test/writers/sbJson/tc_sbjson_id.rb
+++ b/test/writers/sbJson/tc_sbjson_id.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'sbjson_test_parent'
 
-class TestWriterId < TestWriterSbJsonParent
+class TestWriterSbJsonId < TestWriterSbJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterSbJsonParent.getJson('id.json')

--- a/test/writers/sbJson/tc_sbjson_identifier.rb
+++ b/test/writers/sbJson/tc_sbjson_identifier.rb
@@ -1,0 +1,32 @@
+# sbJson 1 writer tests - identifier
+
+# History:
+#  Stan Smith 2017-05-17 original script
+
+require 'minitest/autorun'
+require 'json'
+require 'adiwg-mdtranslator'
+require_relative 'sbjson_test_parent'
+
+class TestWriterSbJsonIdentifier < TestWriterSbJsonParent
+
+   # get input JSON for test
+   @@jsonIn = TestWriterSbJsonParent.getJson('identifier.json')
+
+   def test_citation
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      expect = [{'key'=>'myIdentifier0', 'scheme'=>'mySchema0', 'type'=>'myDescription0'}, {'key'=>'myIdentifier1', 'scheme'=>'mySchema1', 'type'=>'myDescription1'}]
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['identifiers']
+
+      assert_equal expect, got
+
+   end
+
+end
+
+

--- a/test/writers/sbJson/tc_sbjson_resourceInfo.rb
+++ b/test/writers/sbJson/tc_sbjson_resourceInfo.rb
@@ -11,7 +11,7 @@ require_relative 'sbjson_test_parent'
 class TestWriterSbJsonBody < TestWriterSbJsonParent
 
    # get input JSON for test
-   @@jsonIn = TestWriterSbJsonParent.getJson('body.json')
+   @@jsonIn = TestWriterSbJsonParent.getJson('resourceInfo.json')
 
    def test_body
 
@@ -36,6 +36,19 @@ class TestWriterSbJsonBody < TestWriterSbJsonParent
       got = hJsonOut['summary']
 
       assert_equal 'mySummary', got
+
+   end
+
+   def test_purpose
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['purpose']
+
+      assert_equal 'myPurpose', got
 
    end
 

--- a/test/writers/sbJson/tc_sbjson_title.rb
+++ b/test/writers/sbJson/tc_sbjson_title.rb
@@ -1,35 +1,50 @@
-# sbJson 1 writer tests - id
+# sbJson 1 writer tests - title
 
 # History:
-#  Stan Smith 2017-05-13 original script
+#  Stan Smith 2017-05-15 original script
 
 require 'minitest/autorun'
 require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'sbjson_test_parent'
 
-class TestWriterId < TestWriterSbJsonParent
+class TestWriterTitle < TestWriterSbJsonParent
 
    # get input JSON for test
-   @@jsonIn = TestWriterSbJsonParent.getJson('id.json')
+   @@jsonIn = TestWriterSbJsonParent.getJson('title.json')
 
-   def test_id_metadata_identifier
+   def test_title
 
       metadata = ADIWG::Mdtranslator.translate(
          file: @@jsonIn, reader: 'mdJson', validate: 'normal',
          writer: 'sbJson', showAllTags: false)
 
       hJsonOut = JSON.parse(metadata[:writerOutput])
-      got = hJsonOut['id']
+      got = hJsonOut['title']
 
-      assert_equal 'myMetadataIdentifier', got
+      assert_equal 'myCitationTitle', got
 
    end
 
-   def test_id_metadata_citation
+   def test_alternateTitle
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['alternateTitles']
+
+      assert_equal 2, got.length
+      assert_equal 'alternateTitle0', got[0]
+      assert_equal 'alternateTitle1', got[1]
+
+   end
+
+   def test_alternateTitle_missing
 
       hJsonIn = JSON.parse(@@jsonIn)
-      hJsonIn['metadata']['metadataInfo'].delete('metadataIdentifier')
+      hJsonIn['metadata']['resourceInfo']['citation'].delete('alternateTitle')
       hIn = hJsonIn.to_json
 
       metadata = ADIWG::Mdtranslator.translate(
@@ -37,28 +52,12 @@ class TestWriterId < TestWriterSbJsonParent
          writer: 'sbJson', showAllTags: false)
 
       hJsonOut = JSON.parse(metadata[:writerOutput])
-      got = hJsonOut['id']
+      got = hJsonOut['alternateTitles']
 
-      assert_equal 'myCitationIdentifier0', got
-
-   end
-
-   def test_id_default
-
-      hJsonIn = JSON.parse(@@jsonIn)
-      hJsonIn['metadata']['metadataInfo'].delete('metadataIdentifier')
-      hJsonIn['metadata']['resourceInfo']['citation'].delete('identifier')
-      hIn = hJsonIn.to_json
-
-      metadata = ADIWG::Mdtranslator.translate(
-         file: hIn, reader: 'mdJson', validate: 'normal',
-         writer: 'sbJson', showAllTags: false)
-
-      hJsonOut = JSON.parse(metadata[:writerOutput])
-      got = hJsonOut['id']
-
-      refute_nil got
+      assert_nil got
 
    end
 
 end
+
+

--- a/test/writers/sbJson/tc_sbjson_title.rb
+++ b/test/writers/sbJson/tc_sbjson_title.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'adiwg-mdtranslator'
 require_relative 'sbjson_test_parent'
 
-class TestWriterTitle < TestWriterSbJsonParent
+class TestWriterSbJsonTitle < TestWriterSbJsonParent
 
    # get input JSON for test
    @@jsonIn = TestWriterSbJsonParent.getJson('title.json')

--- a/test/writers/sbJson/tc_sbjson_title.rb
+++ b/test/writers/sbJson/tc_sbjson_title.rb
@@ -1,4 +1,4 @@
-# sbJson 1 writer tests - title
+# sbJson 1 writer tests - title/alternateTitles
 
 # History:
 #  Stan Smith 2017-05-15 original script

--- a/test/writers/sbJson/tc_sbjson_title.rb
+++ b/test/writers/sbJson/tc_sbjson_title.rb
@@ -41,6 +41,23 @@ class TestWriterTitle < TestWriterSbJsonParent
 
    end
 
+   def test_alternateTitle_empty
+
+      hJsonIn = JSON.parse(@@jsonIn)
+      hJsonIn['metadata']['resourceInfo']['citation']['alternateTitle'] = []
+      hIn = hJsonIn.to_json
+
+      metadata = ADIWG::Mdtranslator.translate(
+         file: hIn, reader: 'mdJson', validate: 'normal',
+         writer: 'sbJson', showAllTags: false)
+
+      hJsonOut = JSON.parse(metadata[:writerOutput])
+      got = hJsonOut['alternateTitles']
+
+      assert_nil got
+
+   end
+
    def test_alternateTitle_missing
 
       hJsonIn = JSON.parse(@@jsonIn)

--- a/test/writers/sbJson/testData/body.json
+++ b/test/writers/sbJson/testData/body.json
@@ -1,0 +1,58 @@
+{
+   "schema": {
+      "name": "mdJson",
+      "version": "2.0.0"
+   },
+   "contact": [
+      {
+         "contactId": "CID001",
+         "isOrganization": false,
+         "name": "name"
+      }
+   ],
+   "metadata": {
+      "metadataInfo": {
+         "metadataContact": [
+            {
+               "role": "metadataContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ]
+      },
+      "resourceInfo": {
+         "resourceType": [
+            {
+               "type": "type",
+               "name": "name"
+            }
+         ],
+         "citation": {
+            "title": "myCitationTitle"
+         },
+         "abstract": "myBody",
+         "shortAbstract": "mySummary",
+         "status": [
+            "status"
+         ],
+         "pointOfContact": [
+            {
+               "role": "pointOfContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ],
+         "defaultResourceLocale": {
+            "language": "eng",
+            "country": "USA",
+            "characterSet": "UTF-8"
+         }
+      }
+   }
+}

--- a/test/writers/sbJson/testData/citation.json
+++ b/test/writers/sbJson/testData/citation.json
@@ -1,0 +1,128 @@
+{
+   "schema": {
+      "name": "mdJson",
+      "version": "2.0.0"
+   },
+   "contact": [
+      {
+         "contactId": "CID001",
+         "isOrganization": false,
+         "name": "Person 001"
+      },
+      {
+         "contactId": "CID002",
+         "isOrganization": false,
+         "name": "Person 002"
+      },
+      {
+         "contactId": "CID003",
+         "isOrganization": false,
+         "name": "Person 003"
+      },
+      {
+         "contactId": "CID004",
+         "isOrganization": false,
+         "name": "Person 004"
+      },
+      {
+         "contactId": "CID005",
+         "isOrganization": true,
+         "name": "Organization 001"
+      }
+   ],
+   "metadata": {
+      "metadataInfo": {
+         "metadataContact": [
+            {
+               "role": "metadataContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ]
+      },
+      "resourceInfo": {
+         "resourceType": [
+            {
+               "type": "type",
+               "name": "name"
+            }
+         ],
+         "citation": {
+            "title": "myCitationTitle",
+            "responsibleParty": [
+               {
+                  "role": "principalInvestigator",
+                  "party": [
+                     {
+                        "contactId": "CID001"
+                     },
+                     {
+                        "contactId": "CID002"
+                     }
+                  ]
+               },
+               {
+                  "role": "funder",
+                  "party": [
+                     {
+                        "contactId": "CID005",
+                        "organizationMembers": [
+                           "CID003",
+                           "CID004"
+                        ]
+                     }
+                  ]
+               }
+            ],
+            "date": [
+               {
+                  "date": "2017-05",
+                  "dateType": "creation"
+               },
+               {
+                  "date": "2017-05-16",
+                  "dateType": "publish"
+               },
+               {
+                  "date": "2017-05-16T16:10:00-09:00",
+                  "dateType": "revision"
+               }
+            ],
+            "onlineResource": [
+               {
+                  "uri": "http://ISO.uri/adiwg/0",
+                  "protocol": "protocol",
+                  "name": "name",
+                  "description": "description",
+                  "function": "function"
+               },
+               {
+                  "uri": "http://ISO.uri/adiwg/1"
+               }
+            ]
+         },
+         "abstract": "abstract",
+         "status": [
+            "status"
+         ],
+         "pointOfContact": [
+            {
+               "role": "pointOfContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ],
+         "defaultResourceLocale": {
+            "language": "eng",
+            "country": "USA",
+            "characterSet": "UTF-8"
+         }
+      }
+   }
+}

--- a/test/writers/sbJson/testData/citation.json
+++ b/test/writers/sbJson/testData/citation.json
@@ -71,7 +71,8 @@
                         "contactId": "CID005",
                         "organizationMembers": [
                            "CID003",
-                           "CID004"
+                           "CID004",
+                           "CID001"
                         ]
                      }
                   ]
@@ -104,7 +105,7 @@
                }
             ]
          },
-         "abstract": "abstract",
+         "abstract": "myBody",
          "status": [
             "status"
          ],

--- a/test/writers/sbJson/testData/id.json
+++ b/test/writers/sbJson/testData/id.json
@@ -1,0 +1,68 @@
+{
+   "schema": {
+      "name": "mdJson",
+      "version": "2.0.0"
+   },
+   "contact": [
+      {
+         "contactId": "CID001",
+         "isOrganization": false,
+         "name": "name"
+      }
+   ],
+   "metadata": {
+      "metadataInfo": {
+         "metadataIdentifier": {
+            "identifier": "myMetadataIdentifier"
+         },
+         "metadataContact": [
+            {
+               "role": "metadataContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ]
+      },
+      "resourceInfo": {
+         "resourceType": [
+            {
+               "type": "type",
+               "name": "name"
+            }
+         ],
+         "citation": {
+            "title": "title",
+            "identifier": [
+               {
+                  "identifier": "myCitationIdentifier0"
+               },
+               {
+                  "identifier": "myCitationIdentifier1"
+               }
+            ]
+         },
+         "abstract": "abstract",
+         "status": [
+            "status"
+         ],
+         "pointOfContact": [
+            {
+               "role": "pointOfContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ],
+         "defaultResourceLocale": {
+            "language": "eng",
+            "country": "USA",
+            "characterSet": "UTF-8"
+         }
+      }
+   }
+}

--- a/test/writers/sbJson/testData/identifier.json
+++ b/test/writers/sbJson/testData/identifier.json
@@ -1,0 +1,69 @@
+{
+   "schema": {
+      "name": "mdJson",
+      "version": "2.0.0"
+   },
+   "contact": [
+      {
+         "contactId": "CID001",
+         "isOrganization": false,
+         "name": "Person 001"
+      }
+   ],
+   "metadata": {
+      "metadataInfo": {
+         "metadataContact": [
+            {
+               "role": "metadataContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ]
+      },
+      "resourceInfo": {
+         "resourceType": [
+            {
+               "type": "type",
+               "name": "name"
+            }
+         ],
+         "citation": {
+            "title": "myCitationTitle",
+            "identifier": [
+               {
+                  "identifier": "myIdentifier0",
+                  "namespace": "mySchema0",
+                  "description": "myDescription0"
+               },
+               {
+                  "identifier": "myIdentifier1",
+                  "namespace": "mySchema1",
+                  "description": "myDescription1"
+               }
+            ]
+         },
+         "abstract": "myBody",
+         "status": [
+            "status"
+         ],
+         "pointOfContact": [
+            {
+               "role": "pointOfContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ],
+         "defaultResourceLocale": {
+            "language": "eng",
+            "country": "USA",
+            "characterSet": "UTF-8"
+         }
+      }
+   }
+}

--- a/test/writers/sbJson/testData/resourceInfo.json
+++ b/test/writers/sbJson/testData/resourceInfo.json
@@ -35,6 +35,7 @@
          },
          "abstract": "myBody",
          "shortAbstract": "mySummary",
+         "purpose": "myPurpose",
          "status": [
             "status"
          ],

--- a/test/writers/sbJson/testData/title.json
+++ b/test/writers/sbJson/testData/title.json
@@ -1,0 +1,61 @@
+{
+   "schema": {
+      "name": "mdJson",
+      "version": "2.0.0"
+   },
+   "contact": [
+      {
+         "contactId": "CID001",
+         "isOrganization": false,
+         "name": "name"
+      }
+   ],
+   "metadata": {
+      "metadataInfo": {
+         "metadataContact": [
+            {
+               "role": "metadataContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ]
+      },
+      "resourceInfo": {
+         "resourceType": [
+            {
+               "type": "type",
+               "name": "name"
+            }
+         ],
+         "citation": {
+            "title": "myCitationTitle",
+            "alternateTitle": [
+               "alternateTitle0",
+               "alternateTitle1"
+            ]
+         },
+         "abstract": "abstract",
+         "status": [
+            "status"
+         ],
+         "pointOfContact": [
+            {
+               "role": "pointOfContact",
+               "party": [
+                  {
+                     "contactId": "CID001"
+                  }
+               ]
+            }
+         ],
+         "defaultResourceLocale": {
+            "language": "eng",
+            "country": "USA",
+            "characterSet": "UTF-8"
+         }
+      }
+   }
+}

--- a/test/writers/sbJson/xx_writer_sbJson.rb
+++ b/test/writers/sbJson/xx_writer_sbJson.rb
@@ -38,7 +38,7 @@ class Test_Write_sbJSONv0 < MiniTest::Test
     refute_nil metadata[:writerOutput]
   end
 
-  def test_minimum_succes
+  def test_minimum_success
     # get json file for tests from examples folder
     file = File.join(File.dirname(__FILE__), '../../../', 'schemas/v1_0/examples', 'minimum_example.json')
     file = File.open(file, 'r')


### PR DESCRIPTION
ISO topicCategory is now handled in keywords with keywordType = 'isoTopicCategory'.  Values in 'topicCategory' will throw error in mdJson reader.  

gemspec dependency for rgeo and associated activesupport < 5 were removed.

mdTranslator version bump to 2.0.0rc3.

sbJson writer modules and tests for citation, id, identifier, resourceInfo (body, summary, purpose), title are also included. 