### PR TITLE
Minor bug fixes and patches

### DIFF
--- a/lib/adiwg/mdtranslator/readers/fgdc/modules/module_entity.rb
+++ b/lib/adiwg/mdtranslator/readers/fgdc/modules/module_entity.rb
@@ -22,7 +22,11 @@ module ADIWG
                   intMetadataClass = InternalMetadata.new
 
                   # entity attribute 5.1.1 (enttype) - definition and description set
+                  # also search for (enttyp); Metavist and USGS fgdc validator use 'enttyp'
                   xEntity = xDetail.xpath('./enttype')
+                  if xEntity.empty?
+                     xEntity = xDetail.xpath('./enttyp')
+                  end
                   unless xEntity.empty?
 
                      hEntity = intMetadataClass.newEntity

--- a/lib/adiwg/mdtranslator/readers/fgdc/modules/module_spatialDomain.rb
+++ b/lib/adiwg/mdtranslator/readers/fgdc/modules/module_spatialDomain.rb
@@ -61,6 +61,7 @@ module ADIWG
                   intMetadataClass = InternalMetadata.new
                   hExtent = intMetadataClass.newExtent
                   hGeoExtent = intMetadataClass.newGeographicExtent
+                  hExtent[:geographicExtents] << hGeoExtent
 
                   # spatial domain 1.5.1 (bounding) - bounding box
                   xBbox = xDomain.xpath('./bounding')
@@ -127,27 +128,27 @@ module ADIWG
 
                         # make geoJson FeatureCollection from polygon
                         hGeometry = {
-                           type: 'Polygon',
-                           coordinates: polygon
+                           'type' => 'Polygon',
+                           'coordinates' => polygon
                         }
                         hFeature = {
-                           type: 'Feature',
-                           geometry: hGeometry,
-                           properties: {
-                              description: 'FGDC bounding polygon'
+                           'type' => 'Feature',
+                           'geometry' => hGeometry,
+                           'properties' => {
+                              'description' => 'FGDC bounding polygon'
                            }
                         }
                         hCollection = {
-                           type: 'FeatureCollection',
-                           features: [hFeature]
+                           'type' => 'FeatureCollection',
+                           'features' => [hFeature]
                         }
-                        geoJson = hCollection.to_json
+                        geoJson = hCollection
 
                         # make internal geometries from polygon
                         hIntGeo = intMetadataClass.newGeometryObject
                         hIntGeo[:type] = 'Polygon'
                         hIntGeo[:coordinates] = polygon
-                        hIntGeo[:nativeGeoJson] = hGeometry.to_json
+                        hIntGeo[:nativeGeoJson] = hGeometry
 
                         hIntProps = intMetadataClass.newGeometryProperties
                         hIntProps[:description] = 'FGDC bounding polygon'
@@ -155,18 +156,17 @@ module ADIWG
                         hIntFeature = intMetadataClass.newGeometryFeature
                         hIntFeature[:type] = 'Feature'
                         hIntFeature[:geometryObject] = hIntGeo
-                        hIntFeature[:nativeGeoJson] = hFeature.to_json
+                        hIntFeature[:nativeGeoJson] = hFeature
                         hIntFeature[:properties] = hIntProps
 
                         hIntCollect = intMetadataClass.newFeatureCollection
                         hIntCollect[:type] = 'FeatureCollection'
                         hIntCollect[:features] << hIntFeature
-                        hIntCollect[:nativeGeoJson] = hCollection.to_json
+                        hIntCollect[:nativeGeoJson] = hCollection
 
                         hGeoExtent[:geographicElements] << hIntCollect
-                        hGeoExtent[:nativeGeoJson] = geoJson
+                        hGeoExtent[:nativeGeoJson] << geoJson
 
-                        hExtent[:geographicExtents] << hGeoExtent
                         hExtent[:description] = 'FGDC spatial domain'
 
                      end

--- a/lib/adiwg/mdtranslator/readers/sbJson/modules/module_contact.rb
+++ b/lib/adiwg/mdtranslator/readers/sbJson/modules/module_contact.rb
@@ -2,7 +2,8 @@
 # Reader - ScienceBase JSON to internal data structure
 
 # History:
-#   Stan Smith 2016-06-21 original script
+#  Stan Smith 2017-09-13 remove fail restriction on contactType
+#  Stan Smith 2016-06-21 original script
 
 require 'uuidtools'
 require 'adiwg/mdtranslator/internal/internal_metadata_obj'

--- a/lib/adiwg/mdtranslator/readers/sbJson/modules/module_contact.rb
+++ b/lib/adiwg/mdtranslator/readers/sbJson/modules/module_contact.rb
@@ -77,7 +77,6 @@ module ADIWG
                         end
                         if hSbContact['contactType'].nil? || hSbContact['contactType'] == ''
                            hResponseObj[:readerExecutionMessages] << 'Contact contactType is missing'
-                           hResponseObj[:readerExecutionPass] = false
                            return nil
                         end
 

--- a/lib/adiwg/mdtranslator/readers/sbJson/modules/module_contact.rb
+++ b/lib/adiwg/mdtranslator/readers/sbJson/modules/module_contact.rb
@@ -66,19 +66,21 @@ module ADIWG
 
                         hContact[:contactId] = UUIDTools::UUID.random_create.to_s
 
-                        # contact - contactType (required) [ person | organization ]
+                        # contact - contactType [ person | organization ]
                         if hSbContact.has_key?('contactType')
-                           if %w(person organization).include?(hSbContact['contactType'])
+                           if hSbContact['contactType'].nil? || hSbContact['contactType'] == ''
+                              hResponseObj[:readerExecutionMessages] << 'Contact contactType is missing'
+                              hContact[:isOrganization] = false
+                           elsif %w(person organization).include?(hSbContact['contactType'])
                               hContact[:isOrganization] = true if hSbContact['contactType'] == 'organization'
                            else
                               hResponseObj[:readerExecutionMessages] << 'Contact contactType must be person or organization'
                               hResponseObj[:readerExecutionPass] = false
                               return nil
                            end
-                        end
-                        if hSbContact['contactType'].nil? || hSbContact['contactType'] == ''
+                        else
                            hResponseObj[:readerExecutionMessages] << 'Contact contactType is missing'
-                           return nil
+                           hContact[:isOrganization] = false
                         end
 
                         # contact - name (required)

--- a/lib/adiwg/mdtranslator/version.rb
+++ b/lib/adiwg/mdtranslator/version.rb
@@ -1,6 +1,7 @@
 # adiwg mdTranslator
 
 # version 2 history
+# 2.3.1 2017-09-13 fixed fgdc reader: removed conversion of hash to json
 # 2.3.0 2017-09-11 add fgdc 1998 CSDGM reader
 # 2.2.0 2017-08-31 refactor for schema changes to Lineage and Funding
 # 2.1.2 2017-08-24 remove schema version from sbJson
@@ -25,7 +26,7 @@
 module ADIWG
    module Mdtranslator
       # current mdtranslator version
-      VERSION = "2.3.0"
+      VERSION = "2.3.1"
    end
 end
 

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_allocation.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_allocation.rb
@@ -48,7 +48,11 @@ module ADIWG
                   unless hAllocation[:sourceId].nil?
                      hContact = Html_Document.getContact(hAllocation[:sourceId])
                      @html.em('Source Contact: ')
-                     @html.a(hContact[:contactId], 'href' => '#CID_'+hContact[:contactId])
+                     if hContact.empty?
+                        @html.text!("Contact #{hAllocation[:sourceId]} not found!")
+                     else
+                        @html.a(hContact[:contactId], 'href' => '#CID_'+hContact[:contactId])
+                     end
                      @html.br
                   end
 
@@ -56,7 +60,11 @@ module ADIWG
                   unless hAllocation[:recipientId].nil?
                      hContact = Html_Document.getContact(hAllocation[:recipientId])
                      @html.em('Recipient Contact: ')
-                     @html.a(hContact[:contactId], 'href' => '#CID_'+hContact[:contactId])
+                     if hContact.empty?
+                        @html.text!("Contact #{hAllocation[:recipientId]} not found!")
+                     else
+                        @html.a(hContact[:contactId], 'href' => '#CID_'+hContact[:contactId])
+                     end
                      @html.br
                   end
 

--- a/test/readers/fgdc/testData/entityAttribute.xml
+++ b/test/readers/fgdc/testData/entityAttribute.xml
@@ -77,10 +77,10 @@
       </attr>
     </detailed>
     <detailed>
-      <enttype>
+      <enttyp>
         <enttypl>entity 2 label</enttypl>
         <enttypd>entity 2 definition</enttypd>
-      </enttype>
+      </enttyp>
     </detailed>
     <overview>
       <eaover>entity and attribute overview 1</eaover>

--- a/test/readers/sbJson/tc_sbjson_contact.rb
+++ b/test/readers/sbJson/tc_sbjson_contact.rb
@@ -101,72 +101,39 @@ class TestReaderSbJsonContact < TestReaderSbJsonParent
 
       # test response object
       assert hResponse[:readerExecutionPass]
-      assert_empty hResponse[:readerExecutionMessages]
+      refute_empty hResponse[:readerExecutionMessages]
 
    end
 
    def test_contact_empty_elements
 
-      hIn = Marshal::load(Marshal.dump(@@hIn))
-      hIn['contacts'].delete_at(1)
-      hIn0 = hIn['contacts'][0]
-      hIn0['oldPartyId'] = ''
-      hIn0['sourceId'] = ''
-      hIn0['organizationsPerson'] = ''
-      hIn0['ttyPhone'] = ''
-      hIn0['officePhone'] = ''
-      hIn0['faxPhone'] = ''
-      hIn0['hours'] = ''
-      hIn0['instructions'] = ''
-      hIn0['email'] = ''
-      hIn0['active'] = ''
-      hIn0['jobTitle'] = ''
-      hIn0['personalTitle'] = ''
-      hIn0['firstName'] = ''
-      hIn0['middleName'] = ''
-      hIn0['lastName'] = ''
-      hIn0['note'] = ''
-      hIn0['aliases'] = []
-      hIn0['fbmsCodes'] = []
-      hIn0['logoUrl'] = ''
-      hIn0['smallLogoUrl'] = ''
-      hIn0['organization'] = {}
-      hIn0['primaryLocation'] = {}
       hResponse = Marshal::load(Marshal.dump(@@responseObj))
-
-      metadata = @@NameSpace.unpack(hIn, [], hResponse)
-
-      # test array
-      assert_equal 1, metadata.length
-
-      # test person contact
-      hContact = metadata[0]
-      refute_nil hContact[:contactId]
-      refute hContact[:isOrganization]
-      assert_equal 'Robert N Prescott', hContact[:name]
-      assert_equal 'Distributor', hContact[:contactType]
-
-      # empty elements
-      assert_nil hContact[:positionName]
-      assert_empty hContact[:memberOfOrgs]
-      assert_empty hContact[:logos]
-      assert_empty hContact[:phones]
-      assert_empty hContact[:addresses]
-      assert_empty hContact[:eMailList]
-      assert_empty hContact[:onlineResources]
-      assert_empty hContact[:hoursOfService]
-      assert_nil hContact[:contactInstructions]
-
-      assert hResponse[:readerExecutionPass]
-      assert_empty hResponse[:readerExecutionMessages]
-
-   end
-
-   def test_contact_missing_elements
-
       hIn = Marshal::load(Marshal.dump(@@hIn))
       hIn['contacts'].delete_at(0)
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
+      hContact = hIn['contacts'][0]
+      hContact['contactType'] = ''
+      hContact['oldPartyId'] = ''
+      hContact['sourceId'] = ''
+      hContact['organizationsPerson'] = ''
+      hContact['ttyPhone'] = ''
+      hContact['officePhone'] = ''
+      hContact['faxPhone'] = ''
+      hContact['hours'] = ''
+      hContact['instructions'] = ''
+      hContact['email'] = ''
+      hContact['active'] = ''
+      hContact['jobTitle'] = ''
+      hContact['personalTitle'] = ''
+      hContact['firstName'] = ''
+      hContact['middleName'] = ''
+      hContact['lastName'] = ''
+      hContact['note'] = ''
+      hContact['aliases'] = []
+      hContact['fbmsCodes'] = []
+      hContact['logoUrl'] = ''
+      hContact['smallLogoUrl'] = ''
+      hContact['organization'] = {}
+      hContact['primaryLocation'] = {}
 
       metadata = @@NameSpace.unpack(hIn, [], hResponse)
 
@@ -192,16 +159,50 @@ class TestReaderSbJsonContact < TestReaderSbJsonParent
       assert_nil hContact[:contactInstructions]
 
       assert hResponse[:readerExecutionPass]
-      assert_empty hResponse[:readerExecutionMessages]
+      refute_empty hResponse[:readerExecutionMessages]
+
+   end
+
+   def test_contact_missing_elements
+
+      hResponse = Marshal::load(Marshal.dump(@@responseObj))
+      hIn = Marshal::load(Marshal.dump(@@hIn))
+      hIn['contacts'].delete_at(0)
+
+      metadata = @@NameSpace.unpack(hIn, [], hResponse)
+
+      # test array
+      assert_equal 1, metadata.length
+
+      # test person contact
+      hContact = metadata[0]
+      refute_nil hContact[:contactId]
+      refute hContact[:isOrganization]
+      assert_equal 'Jordan S Read', hContact[:name]
+      assert_equal 'Metadata Contact', hContact[:contactType]
+
+      # empty elements
+      assert_nil hContact[:positionName]
+      assert_empty hContact[:memberOfOrgs]
+      assert_empty hContact[:logos]
+      assert_empty hContact[:phones]
+      assert_empty hContact[:addresses]
+      assert_empty hContact[:eMailList]
+      assert_empty hContact[:onlineResources]
+      assert_empty hContact[:hoursOfService]
+      assert_nil hContact[:contactInstructions]
+
+      assert hResponse[:readerExecutionPass]
+      refute_empty hResponse[:readerExecutionMessages]
 
    end
 
    def test_contact_name_empty
 
+      hResponse = Marshal::load(Marshal.dump(@@responseObj))
       hIn = Marshal::load(Marshal.dump(@@hIn))
       hIn['contacts'].delete_at(0)
       hIn['contacts'][0]['name'] = ''
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
 
       metadata = @@NameSpace.unpack(hIn, [], hResponse)
 
@@ -214,42 +215,10 @@ class TestReaderSbJsonContact < TestReaderSbJsonParent
 
    def test_contact_name_missing
 
+      hResponse = Marshal::load(Marshal.dump(@@responseObj))
       hIn = Marshal::load(Marshal.dump(@@hIn))
       hIn['contacts'].delete_at(0)
       hIn['contacts'][0].delete('name')
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
-
-      metadata = @@NameSpace.unpack(hIn, [], hResponse)
-
-      # test array
-      assert_nil metadata
-      refute hResponse[:readerExecutionPass]
-      refute_empty hResponse[:readerExecutionMessages]
-
-   end
-
-   def test_contact_contactType_empty
-
-      hIn = Marshal::load(Marshal.dump(@@hIn))
-      hIn['contacts'].delete_at(0)
-      hIn['contacts'][0]['contactType'] = ''
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
-
-      metadata = @@NameSpace.unpack(hIn, [], hResponse)
-
-      # test array
-      assert_nil metadata
-      refute hResponse[:readerExecutionPass]
-      refute_empty hResponse[:readerExecutionMessages]
-
-   end
-
-   def test_contact_contactType_missing
-
-      hIn = Marshal::load(Marshal.dump(@@hIn))
-      hIn['contacts'].delete_at(0)
-      hIn['contacts'][0].delete('contactType')
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
 
       metadata = @@NameSpace.unpack(hIn, [], hResponse)
 
@@ -262,42 +231,10 @@ class TestReaderSbJsonContact < TestReaderSbJsonParent
 
    def test_contact_contactType_invalid
 
+      hResponse = Marshal::load(Marshal.dump(@@responseObj))
       hIn = Marshal::load(Marshal.dump(@@hIn))
       hIn['contacts'].delete_at(0)
       hIn['contacts'][0]['contactType'] = 'badName'
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
-
-      metadata = @@NameSpace.unpack(hIn, [], hResponse)
-
-      # test array
-      assert_nil metadata
-      refute hResponse[:readerExecutionPass]
-      refute_empty hResponse[:readerExecutionMessages]
-
-   end
-
-   def test_contact_type_empty
-
-      hIn = Marshal::load(Marshal.dump(@@hIn))
-      hIn['contacts'].delete_at(0)
-      hIn['contacts'][0]['type'] = ''
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
-
-      metadata = @@NameSpace.unpack(hIn, [], hResponse)
-
-      # test array
-      assert_nil metadata
-      refute hResponse[:readerExecutionPass]
-      refute_empty hResponse[:readerExecutionMessages]
-
-   end
-
-   def test_contact_type_missing
-
-      hIn = Marshal::load(Marshal.dump(@@hIn))
-      hIn['contacts'].delete_at(0)
-      hIn['contacts'][0].delete('type')
-      hResponse = Marshal::load(Marshal.dump(@@responseObj))
 
       metadata = @@NameSpace.unpack(hIn, [], hResponse)
 

--- a/test/readers/sbJson/testData/contact.json
+++ b/test/readers/sbJson/testData/contact.json
@@ -62,8 +62,7 @@
       },
       {
          "name": "Jordan S Read",
-         "type": "Metadata Contact",
-         "contactType": "person"
+         "type": "Metadata Contact"
       }
    ]
 }


### PR DESCRIPTION
 * resolve conflict between FGDC documentation and Metivist by permitting two tag names for *entity*
 * fix problem of fgdc reader generated GeoJSON presenting as string
 * handle invalid source and recipient IDs in html writer
 * remove requirement for *contactType* in sbJson reader 

Bump version to 2.3.1