### PR TITLE
287 fix and update unit tests

### DIFF
--- a/test/debug/debug_test_parent.rb
+++ b/test/debug/debug_test_parent.rb
@@ -12,7 +12,7 @@ require 'rubygems'
 require 'adiwg-mdjson_schemas'
 require 'adiwg/mdtranslator'
 
-class TestDebugParent < MiniTest::Test
+class TestDebugParent < Minitest::Test
 
    @@responseObj = {
       readerExecutionPass: true,

--- a/test/readers/fgdc/fgdc_test_parent.rb
+++ b/test/readers/fgdc/fgdc_test_parent.rb
@@ -11,7 +11,7 @@ require 'adiwg/mdtranslator'
 require 'adiwg/mdtranslator/internal/internal_metadata_obj'
 require 'adiwg/mdtranslator/readers/fgdc/modules/module_fgdc'
 
-class TestReaderFGDCParent < MiniTest::Test
+class TestReaderFGDCParent < Minitest::Test
 
    @@hResponseObj = {
       readerExecutionPass: true,

--- a/test/readers/mdJson/mdjson_test_parent.rb
+++ b/test/readers/mdJson/mdjson_test_parent.rb
@@ -14,7 +14,7 @@ require 'adiwg/mdtranslator/readers/mdJson/modules/module_mdJson'
 require_relative '../../helpers/mdJson_hash_objects'
 require_relative '../../helpers/mdJson_hash_functions'
 
-class TestReaderMdJsonParent < MiniTest::Test
+class TestReaderMdJsonParent < Minitest::Test
 
    # instance classes needed in script
    TDClass = MdJsonHashWriter.new

--- a/test/readers/sbJson/sbjson_test_parent.rb
+++ b/test/readers/sbJson/sbjson_test_parent.rb
@@ -10,7 +10,7 @@ require 'json-schema'
 require 'adiwg-mdjson_schemas'
 require 'adiwg/mdtranslator/readers/sbJson/modules/module_sbJson'
 
-class TestReaderSbJsonParent < MiniTest::Test
+class TestReaderSbJsonParent < Minitest::Test
 
    @@responseObj = {
       readerExecutionPass: true,

--- a/test/translator/tc_fgdc_reader.rb
+++ b/test/translator/tc_fgdc_reader.rb
@@ -9,7 +9,7 @@ require 'nokogiri'
 require 'adiwg/mdtranslator'
 require 'adiwg/mdtranslator/readers/fgdc/version'
 
-class TestFgdcReader < MiniTest::Test
+class TestFgdcReader < Minitest::Test
 
     def test_fgdc_reader_badly_formed_xml
 

--- a/test/translator/tc_mdJson_reader.rb
+++ b/test/translator/tc_mdJson_reader.rb
@@ -9,7 +9,7 @@ require 'json'
 require 'rubygems'
 require 'adiwg/mdtranslator'
 
-class TestMdJsonReader < MiniTest::Test
+class TestMdJsonReader < Minitest::Test
 
    def test_mdJson_reader_invalid_mdJson
 

--- a/test/translator/tc_mdJson_schemaExample.rb
+++ b/test/translator/tc_mdJson_schemaExample.rb
@@ -8,7 +8,7 @@ require 'minitest/autorun'
 require 'rubygems'
 require 'adiwg/mdtranslator'
 
-class TestMdjsonSchemaExample < MiniTest::Test
+class TestMdjsonSchemaExample < Minitest::Test
    
    def test_mdJson_schema_example
       

--- a/test/translator/tc_mdReaders.rb
+++ b/test/translator/tc_mdReaders.rb
@@ -8,7 +8,7 @@ require 'minitest/autorun'
 require 'json'
 require 'adiwg/mdtranslator'
 
-class TestMdReaders < MiniTest::Test
+class TestMdReaders < Minitest::Test
 
     # read in an mdJson 2.x file
     file = File.join(File.dirname(__FILE__), 'testData', 'mdJson_minimal.json')

--- a/test/translator/tc_mdWriters.rb
+++ b/test/translator/tc_mdWriters.rb
@@ -8,7 +8,7 @@ require 'minitest/autorun'
 require 'json'
 require 'adiwg/mdtranslator'
 
-class TestMdWriters < MiniTest::Test
+class TestMdWriters < Minitest::Test
 
    # read in an mdJson 2.x file
    file = File.join(File.dirname(__FILE__), 'testData', 'mdJson_minimal.json')

--- a/test/translator/tc_mdtranslator.rb
+++ b/test/translator/tc_mdtranslator.rb
@@ -10,7 +10,7 @@ require 'minitest/autorun'
 require 'json'
 require 'adiwg/mdtranslator'
 
-class TestMdTranslator < MiniTest::Test
+class TestMdTranslator < Minitest::Test
 
    # read in an mdJson 2.x test file
    file = File.join(File.dirname(__FILE__), 'testData', 'mdJson_minimal.json')

--- a/test/translator/tc_mdtranslator_CLI.rb
+++ b/test/translator/tc_mdtranslator_CLI.rb
@@ -10,7 +10,7 @@ require_relative '../../lib/adiwg/mdtranslator_cli'
 
 # test CLI parameters
 # no writer is specified; the input mdJson will only be scanned for errors
-class TestMdtranslatorCLI < MiniTest::Test
+class TestMdtranslatorCLI < Minitest::Test
 
     def test_mdtranslatorCLI_default
 

--- a/test/translator/tc_sbJson_reader.rb
+++ b/test/translator/tc_sbJson_reader.rb
@@ -9,7 +9,7 @@ require 'json'
 require 'adiwg/mdtranslator'
 require 'adiwg/mdtranslator/readers/sbJson/version'
 
-class TestSbJsonReader < MiniTest::Test
+class TestSbJsonReader < Minitest::Test
 
    def test_sbJson_reader_invalid_sbJson
 

--- a/test/translator/tc_translator_roundTrip.rb
+++ b/test/translator/tc_translator_roundTrip.rb
@@ -9,7 +9,7 @@ require 'nokogiri'
 require 'adiwg/mdtranslator'
 require 'adiwg/mdtranslator/readers/fgdc/version'
 
-class TestTranslatorRoundTrip < MiniTest::Test
+class TestTranslatorRoundTrip < Minitest::Test
 
     def test_fgdc_demo_to_iso191152
 

--- a/test/writers/fgdc/fgdc_test_parent.rb
+++ b/test/writers/fgdc/fgdc_test_parent.rb
@@ -11,7 +11,7 @@ require 'nokogiri'
 require 'rubygems'
 require 'adiwg/mdtranslator'
 
-class TestWriterFGDCParent < MiniTest::Test
+class TestWriterFGDCParent < Minitest::Test
 
    @@responseObj = {
       readerExecutionPass: true,

--- a/test/writers/html/tc_html_document.rb
+++ b/test/writers/html/tc_html_document.rb
@@ -7,7 +7,7 @@ require 'minitest/autorun'
 require 'json'
 require 'adiwg-mdtranslator'
 
-class TestHtmlDocument < MiniTest::Test
+class TestHtmlDocument < Minitest::Test
 
    # get input JSON for test
    fname = File.join(File.dirname(__FILE__), 'testData', 'metadataGeo.json')

--- a/test/writers/iso19110/iso19110_test_parent.rb
+++ b/test/writers/iso19110/iso19110_test_parent.rb
@@ -11,7 +11,7 @@ require 'nokogiri'
 require 'adiwg-mdjson_schemas'
 require 'adiwg/mdtranslator'
 
-class TestWriter19110Parent < MiniTest::Test
+class TestWriter19110Parent < Minitest::Test
 
    @@responseObj = {
       readerExecutionPass: true,

--- a/test/writers/iso19115-1/iso19115_1_test_parent.rb
+++ b/test/writers/iso19115-1/iso19115_1_test_parent.rb
@@ -11,7 +11,7 @@ require 'nokogiri'
 require 'adiwg-mdjson_schemas'
 require 'adiwg/mdtranslator'
 
-class TestWriter191151Parent < MiniTest::Test
+class TestWriter191151Parent < Minitest::Test
 
    @@responseObj = {
       readerExecutionPass: true,

--- a/test/writers/iso19115-1/tc_19115_1_partyIdentifier.rb
+++ b/test/writers/iso19115-1/tc_19115_1_partyIdentifier.rb
@@ -29,7 +29,7 @@ class TestWriter19115PartyIdentifier < TestWriter191151Parent
         ] 
       },
       {
-        name: "person name",
+        name: "expected person name",
         isOrganization: false,
         contactId: "CID002",
         externalIdentifier: [
@@ -48,7 +48,7 @@ class TestWriter19115PartyIdentifier < TestWriter191151Parent
 
     hIn[:metadata][:resourceInfo][:citation][:responsibleParty][0][:party] = parties
 
-    hReturn = TestWriter191151Parent.run_test(hIn, '19115_1_partyIdentifier', '//cit:party[2]', '//cit:party', 0)
+    hReturn = TestWriter191151Parent.run_test(hIn, '19115_1_partyIdentifier', '//cit:party[1]', '//cit:party', 0)
 
     assert_equal hReturn[0], hReturn[1]
     assert hReturn[2]

--- a/test/writers/iso19115-1/tc_19115_1_partyIdentifier.rb
+++ b/test/writers/iso19115-1/tc_19115_1_partyIdentifier.rb
@@ -29,7 +29,7 @@ class TestWriter19115PartyIdentifier < TestWriter191151Parent
         ] 
       },
       {
-        name: "expected person name",
+        name: "person name",
         isOrganization: false,
         contactId: "CID002",
         externalIdentifier: [

--- a/test/writers/iso19115-1/tc_19115_1_partyIdentifier.rb
+++ b/test/writers/iso19115-1/tc_19115_1_partyIdentifier.rb
@@ -31,7 +31,7 @@ class TestWriter19115PartyIdentifier < TestWriter191151Parent
       {
         name: "person name",
         isOrganization: false,
-        contactId: "CID001",
+        contactId: "CID002",
         externalIdentifier: [
           {
             identifier: "https://orcid.org/0000-0002-4472-5965",

--- a/test/writers/iso19115-1/testData/19115_1_partyIdentifier.xml
+++ b/test/writers/iso19115-1/testData/19115_1_partyIdentifier.xml
@@ -36,7 +36,7 @@
   <cit:party>
     <cit:CI_Individual>
       <cit:name>
-        <gco:CharacterString>expected person name</gco:CharacterString>
+        <gco:CharacterString>person name</gco:CharacterString>
       </cit:name>
       <cit:contactInfo/>
       <cit:partyIdentifier>

--- a/test/writers/iso19115-2/iso19115_2_test_parent.rb
+++ b/test/writers/iso19115-2/iso19115_2_test_parent.rb
@@ -11,7 +11,7 @@ require 'nokogiri'
 require 'adiwg-mdjson_schemas'
 require 'adiwg/mdtranslator'
 
-class TestWriter191152Parent < MiniTest::Test
+class TestWriter191152Parent < Minitest::Test
 
    @@responseObj = {
       readerExecutionPass: true,

--- a/test/writers/mdJson/mdjson_test_parent.rb
+++ b/test/writers/mdJson/mdjson_test_parent.rb
@@ -10,7 +10,7 @@ require 'json'
 require 'json-schema'
 require 'adiwg-mdjson_schemas'
 
-class TestWriterMdJsonParent < MiniTest::Test
+class TestWriterMdJsonParent < Minitest::Test
 
    # get json file for tests from examples folder
    def self.getJson(fileName)

--- a/test/writers/sbJson/sbjson_test_parent.rb
+++ b/test/writers/sbJson/sbjson_test_parent.rb
@@ -8,7 +8,7 @@ require 'minitest/autorun'
 require 'json'
 require 'json-schema'
 
-class TestWriterSbJsonParent < MiniTest::Test
+class TestWriterSbJsonParent < Minitest::Test
 
    # get json file for tests from examples folder
    def self.getJson(fileName)


### PR DESCRIPTION
Closes #295, closes #296

## Changes

- Update MiniTest to Minitest, this is a name change coming from upgrading the testing library version
- Fixed ISO party identifier test
- Updated/fixed the ISO party identifier test file