### PR TITLE
Data Quality Reports - HTML Writer (and some bugfixes - internal object, mdJson reader/writer)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adiwg-mdtranslator (2.18.4)
+    adiwg-mdtranslator (2.18.5.pre.beta.1)
       adiwg-mdcodes (= 2.8.4)
       adiwg-mdjson_schemas (= 2.8.1)
       builder (~> 3.2)

--- a/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
+++ b/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
@@ -654,7 +654,7 @@ class InternalMetadata
       {
          dateTime: nil,
          scope: {},
-         spatialRepresentationType: {},
+         spatialRepresentationType: nil,
          spatialRepresentation: {},
          resultContent: [],
          resourceFormat: {},
@@ -705,15 +705,12 @@ class InternalMetadata
 
    def newDataQualityReport
       {
-         # standaloneQualityReportDetails: nil,
+         qualityMeasure: {},
+         evaluationMethod: [],
          conformanceResult: [],
          coverageResult: [],
-         # derivedElementReport: [],
          descriptiveResult: [],
-         evaluationMethod: {},
-         qualityMeasure: {},
          quantitativeResult: [],
-         # relatedElementReport: []
       }
    end
 
@@ -721,7 +718,6 @@ class InternalMetadata
       {
          reportReference: {},
          abstract: nil,
-         elementReports: []
       }
    end
 

--- a/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
+++ b/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
@@ -657,8 +657,8 @@ class InternalMetadata
          spatialRepresentationType: nil,
          spatialRepresentation: {},
          resultContent: [],
-         resourceFormat: {},
-         resultFile: {}
+         resourceFormat: nil,
+         resultFile: nil
       }
    end
 

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_conformanceResult.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_conformanceResult.rb
@@ -8,7 +8,7 @@ module ADIWG
 
         module ConformanceResult
 
-          def self.unpack(hConformanceResult, responseObj, inContext = nil)
+          def self.unpack(hConformanceResult, responseObj)
 
             intMetadataClass = InternalMetadata.new
             intConformanceResult = intMetadataClass.newConformanceResult

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_coverageResult.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_coverageResult.rb
@@ -7,7 +7,7 @@ module ADIWG
       module MdJson
 
         module CoverageResult
-          def self.unpack(hResult, responseObj, inContext)
+          def self.unpack(hResult, responseObj)
 
             intMetadataClass = InternalMetadata.new
             intResult = intMetadataClass.newCoverageResult
@@ -25,7 +25,6 @@ module ADIWG
 
 
             # spatialRepresentationType
-            # https://github.com/ISO-TC211/XML/blob/master/standards.iso.org/iso/19115/resources/Codelists/gml/MD_SpatialRepresentationTypeCode.xml
             if hResult.has_key?('spatialRepresentationType')
               intResult[:spatialRepresentationType] = hResult['spatialRepresentationType']
             end
@@ -50,7 +49,6 @@ module ADIWG
 
 
             # resultFile
-            resultFile
             if hResult.has_key?('resultFile')
               intResult[:resultFile] = hResult['resultFile']
             end

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_dataQuality.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_dataQuality.rb
@@ -41,7 +41,7 @@ module ADIWG
                 intDataQuality[:standaloneReport] = {}
                 intDataQuality[:standaloneReport][:abstract] = hObject["abstract"]
 
-                unless hObject["reportRefereence"].nil? || hObject["reportReference"].empty?
+                unless hObject["reportReference"].nil? || hObject["reportReference"].empty?
                   intDataQuality[:standaloneReport][:reportReference] = Citation.unpack(hObject["reportReference"], responseObj, inContext)
                 end
               end

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_dataQuality.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_dataQuality.rb
@@ -38,11 +38,11 @@ module ADIWG
             if hDataQuality.has_key?('standaloneQualityReport')
               hObject = hDataQuality['standaloneQualityReport']
               unless hObject.empty?
-                intDataQuality[:standaloneQualityReport] = {}
-                intDataQuality[:standaloneQualityReport][:abstract] = hObject["abstract"]
+                intDataQuality[:standaloneReport] = {}
+                intDataQuality[:standaloneReport][:abstract] = hObject["abstract"]
 
                 unless hObject["reportRefereence"].nil? || hObject["reportReference"].empty?
-                  intDataQuality[:standaloneQualityReport][:reportReference] = Citation.unpack(hObject["reportReference"], responseObj, inContext)
+                  intDataQuality[:standaloneReport][:reportReference] = Citation.unpack(hObject["reportReference"], responseObj, inContext)
                 end
               end
             end

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_dataQualityReport.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_dataQualityReport.rb
@@ -60,10 +60,12 @@ module ADIWG
             end
 
             if hReport.has_key?('evaluationMethod')
-              hReturn = EvaluationMethod.unpack(hReport['evaluationMethod'], responseObj)
+              hReport['evaluationMethod'].each do |item|
+                hReturn = EvaluationMethod.unpack(item, responseObj)
 
-              unless hReturn.nil?
-                intReport[:evaluationMethod] = hReturn
+                unless hReturn.nil?
+                  intReport[:evaluationMethod] << hReturn
+                end
               end
             end
 
@@ -97,7 +99,6 @@ module ADIWG
                 end
               end
             end
-
 
             return intReport
           end

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_evaluationMethod.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_evaluationMethod.rb
@@ -6,7 +6,7 @@ module ADIWG
       module MdJson
 
         module EvaluationMethod
-          def self.unpack(hMethod, responseObj, inContext = nil)
+          def self.unpack(hMethod, responseObj)
 
             intMetadataClass = InternalMetadata.new
             intMethod = intMetadataClass.newEvaluationMethod

--- a/lib/adiwg/mdtranslator/version.rb
+++ b/lib/adiwg/mdtranslator/version.rb
@@ -109,7 +109,7 @@
 module ADIWG
    module Mdtranslator
       # current mdtranslator version
-      VERSION = "2.18.4"
+      VERSION = "2.18.5-beta.1"
    end
 end
 

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_body.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_body.rb
@@ -71,6 +71,7 @@ module ADIWG
                         @html.a(' Contacts', {'href' => '#body-contacts', 'class' => 'btn navBtn', 'id' => 'contactButton'})
                         @html.a(' Metadata', {'href' => '#body-metadataInfo', 'class' => 'btn navBtn', 'id' => 'metadataButton'})
                         @html.a(' Resource', {'href' => '#body-resourceInfo', 'class' => 'btn navBtn', 'id' => 'resourceButton'})
+                        @html.a(' Quality', {'href' => '#body-dataQuality', 'class' => 'btn navBtn', 'id' => 'qualityButton'})
                         @html.a(' Lineage', {'href' => '#body-lineage', 'class' => 'btn navBtn', 'id' => 'lineageButton'})
                         @html.a(' Distribution', {'href' => '#body-distribution', 'class' => 'btn navBtn', 'id' => 'distributionButton'})
                         @html.a(' Associated', {'href' => '#body-associatedResource', 'class' => 'btn navBtn', 'id' => 'associatedButton'})
@@ -169,7 +170,10 @@ module ADIWG
                            @html.summary('Data Quality', {'id' => 'body-dataQuality', 'class' => 'h2'})
                            aDataQuality.each do |hDataQuality|
                               @html.section(:class => 'block') do
-                                 dataQualityClass.writeHtml(hDataQuality)
+                                 @html.details do
+                                    @html.summary('Quality', {'class' => 'h3'})
+                                    dataQualityClass.writeHtml(hDataQuality)
+                                 end
                               end
                            end
                         end

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_citation.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_citation.rb
@@ -25,6 +25,9 @@ module ADIWG
                end
 
                def writeHtml(hCitation)
+                  if hCitation.nil? || hCitation.empty?
+                     return
+                  end
 
                   # classes used
                   dateClass = Html_Date.new(@html)

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_dataQuality.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_dataQuality.rb
@@ -1,5 +1,6 @@
 require_relative 'html_citation'
 require_relative 'html_dataQualityReport'
+require_relative 'html_scope'
 
 module ADIWG
   module Mdtranslator
@@ -15,6 +16,7 @@ module ADIWG
             scopeClass = Html_Scope.new(@html)
             dataQualityReportClass = Html_DataQualityReport.new(@html)
 
+            # scope
             unless hDataQuality[:scope].nil? || hDataQuality[:scope].empty?
               @html.section(class: 'block') do
                 @html.details do
@@ -26,12 +28,11 @@ module ADIWG
               end
             end
 
-
-            unless hDataQuality[:standaloneQualityReport].nil? || 
-                   ( hDataQuality[:standaloneQualityReport][:abstract].nil? && 
-                     hDataQuality[:standaloneQualityReport][:reportReference].nil? )
-              report = hDataQuality[:standaloneQualityReport]
-
+            # standalone quality report
+            unless hDataQuality[:standaloneReport].nil? || 
+                   ( hDataQuality[:standaloneReport][:abstract].nil? && 
+                     hDataQuality[:standaloneReport][:reportReference].nil? )
+              report = hDataQuality[:standaloneReport]
               @html.section(class: 'block') do
                 @html.details do
                   @html.summary('Standalone Quality Report', {'class' => 'h5'})
@@ -41,7 +42,6 @@ module ADIWG
                       @html.text!(report[:abstract])
                     end
                   end
-
                   unless report[:reportReference].nil?
                     @html.details do
                       @html.summary('Report Reference', {'class' => 'h5'})
@@ -52,15 +52,14 @@ module ADIWG
                   end
                 end
               end
-              
             end
 
-
-            unless report[:reports].nil? || report[:reports].empty?
+            # reports
+            unless hDataQuality[:report].nil? || hDataQuality[:report].empty?
               @html.section(class: 'block') do
                 @html.details do
                   @html.summary('Reports', {'class' => 'h5'})
-                  report[:reports].each do |report|
+                  hDataQuality[:report].each do |report|
                     @html.section(class: 'block') do
                       @html.details do
                         @html.summary('Report', {'class' => 'h5'})

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_dataQuality.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_dataQuality.rb
@@ -1,4 +1,5 @@
 require_relative 'html_citation'
+require_relative 'html_dataQualityReport'
 
 module ADIWG
   module Mdtranslator
@@ -12,6 +13,7 @@ module ADIWG
           def writeHtml(hDataQuality)
             citationClass = Html_Citation.new(@html)
             scopeClass = Html_Scope.new(@html)
+            dataQualityReportClass = Html_DataQualityReport.new(@html)
 
             unless hDataQuality[:scope].nil? || hDataQuality[:scope].empty?
               @html.section(class: 'block') do
@@ -50,8 +52,28 @@ module ADIWG
                   end
                 end
               end
-
+              
             end
+
+
+            unless report[:reports].nil? || report[:reports].empty?
+              @html.section(class: 'block') do
+                @html.details do
+                  @html.summary('Reports', {'class' => 'h5'})
+                  report[:reports].each do |report|
+                    @html.section(class: 'block') do
+                      @html.details do
+                        @html.summary('Report', {'class' => 'h5'})
+                        @html.section(class: 'block') do
+                          dataQualityReportClass.writeHtml(report)
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+
           end
         end
       end

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_dataQuality.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_dataQuality.rb
@@ -20,7 +20,7 @@ module ADIWG
             unless hDataQuality[:scope].nil? || hDataQuality[:scope].empty?
               @html.section(class: 'block') do
                 @html.details do
-                  @html.summary('Scope', {'class' => 'h5'})
+                  @html.summary('Scope', {'class' => 'h4'})
                   @html.section(class: 'block') do
                     scopeClass.writeHtml(hDataQuality[:scope])
                   end
@@ -35,7 +35,7 @@ module ADIWG
               report = hDataQuality[:standaloneReport]
               @html.section(class: 'block') do
                 @html.details do
-                  @html.summary('Standalone Quality Report', {'class' => 'h5'})
+                  @html.summary('Standalone Quality Report', {'class' => 'h4'})
                   unless report[:abstract].nil?
                     @html.section(class: 'block') do
                       @html.em('Abstract:')
@@ -43,10 +43,12 @@ module ADIWG
                     end
                   end
                   unless report[:reportReference].nil?
-                    @html.details do
-                      @html.summary('Report Reference', {'class' => 'h5'})
-                      @html.section(class: 'block') do
-                        citationClass.writeHtml(report[:reportReference])
+                    @html.section(class: 'block') do
+                      @html.details do
+                        @html.summary('Report Reference', {'class' => 'h5'})
+                        @html.section(class: 'block') do
+                          citationClass.writeHtml(report[:reportReference])
+                        end
                       end
                     end
                   end
@@ -58,14 +60,12 @@ module ADIWG
             unless hDataQuality[:report].nil? || hDataQuality[:report].empty?
               @html.section(class: 'block') do
                 @html.details do
-                  @html.summary('Reports', {'class' => 'h5'})
+                  @html.summary('Reports', {'class' => 'h4'})
                   hDataQuality[:report].each do |report|
                     @html.section(class: 'block') do
                       @html.details do
                         @html.summary('Report', {'class' => 'h5'})
-                        @html.section(class: 'block') do
-                          dataQualityReportClass.writeHtml(report)
-                        end
+                        dataQualityReportClass.writeHtml(report)
                       end
                     end
                   end

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_dataQualityReport.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_dataQualityReport.rb
@@ -13,16 +13,23 @@ module ADIWG
           end
 
           def writeHtml(hDataQualityReport)
-            @html.details do
-              @html.summary('Report', {'class' => 'h5'})
-              @html.section(class: 'block') do
-                writeQualityMeasure(hDataQualityReport[:qualityMeasure]) unless hDataQualityReport[:qualityMeasure].empty?
-                writeEvaluationMethod(hDataQualityReport[:evaluationMethod]) unless hDataQualityReport[:evaluationMethod].empty?
-                writeConformanceResult(hDataQualityReport[:conformanceResult]) unless hDataQualityReport[:conformanceResult].empty?
-                writeCoverageResult(hDataQualityReport[:coverageResult]) unless hDataQualityReport[:coverageResult].empty?
-                writeDescriptiveResult(hDataQualityReport[:descriptiveResult]) unless hDataQualityReport[:descriptiveResult].empty?
-                writeQuantitativeResult(hDataQualityReport[:quantitativeResult]) unless hDataQualityReport[:quantitativeResult].empty?
-              end
+            @html.section(class: 'block') do
+              writeQualityMeasure(hDataQualityReport[:qualityMeasure]) unless hDataQualityReport[:qualityMeasure].nil?
+            end
+            @html.section(class: 'block') do
+              writeEvaluationMethod(hDataQualityReport[:evaluationMethod]) unless hDataQualityReport[:evaluationMethod].empty?
+            end
+            @html.section(class: 'block') do
+              writeConformanceResult(hDataQualityReport[:conformanceResult]) unless hDataQualityReport[:conformanceResult].empty?
+            end
+            @html.section(class: 'block') do
+              writeCoverageResult(hDataQualityReport[:coverageResult]) unless hDataQualityReport[:coverageResult].empty?
+            end
+            @html.section(class: 'block') do
+              writeDescriptiveResult(hDataQualityReport[:descriptiveResult]) unless hDataQualityReport[:descriptiveResult].empty?
+            end
+            @html.section(class: 'block') do
+              writeQuantitativeResult(hDataQualityReport[:quantitativeResult]) unless hDataQualityReport[:quantitativeResult].empty?
             end
           end
 
@@ -64,81 +71,84 @@ module ADIWG
           def writeEvaluationMethod(evaluationMethod)
             citationClass = Html_Citation.new(@html)
           
-            evaluationMethod.each do |method|
-              @html.section(class: 'block') do
-                # Type
-                unless method[:type].nil?
-                  @html.em('Type: ')
-                  @html.text!(method[:type])
-                  @html.br
-                end
-          
-                # DateTime
-                unless method[:dateTime].nil?
-                  @html.em('Date Time: ')
-                  @html.text!(method[:dateTime])
-                  @html.br
-                end
-          
-                # MethodDescription
-                unless method[:methodDescription].nil?
-                  @html.em('Method Description: ')
-                  @html.text!(method[:methodDescription])
-                  @html.br
-                end
-          
-                # EvaluationMethodType
-                unless method[:evaluationMethodType].nil?
-                  @html.em('Evaluation Method Type: ')
-                  @html.text!(method[:evaluationMethodType])
-                  @html.br
-                end
-          
-                # DeductiveSource
-                unless method[:deductiveSource].nil?
-                  @html.em('Deductive Source: ')
-                  @html.text!(method[:deductiveSource])
-                  @html.br
-                end
-          
-                # SamplingScheme
-                unless method[:samplingScheme].nil?
-                  @html.em('Sampling Scheme: ')
-                  @html.text!(method[:samplingScheme])
-                  @html.br
-                end
-          
-                # LotDescription
-                unless method[:lotDescription].nil?
-                  @html.em('Lot Description: ')
-                  @html.text!(method[:lotDescription])
-                  @html.br
-                end
-          
-                # SamplingRatio
-                unless method[:samplingRatio].nil?
-                  @html.em('Sampling Ratio: ')
-                  @html.text!(method[:samplingRatio])
-                  @html.br
-                end
-          
-                # EvaluationProcedure
-                unless method[:evaluationProcedure].nil?
-                  @html.details do
-                    @html.summary('Evaluation Procedure', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      citationClass.writeHtml(method[:evaluationProcedure])
+            @html.details do
+              @html.summary('Evaluation Method', {'class' => 'h5'})
+              evaluationMethod.each do |method|
+                @html.section(class: 'block') do
+                  # Type
+                  unless method[:type].nil?
+                    @html.em('Type: ')
+                    @html.text!(method[:type])
+                    @html.br
+                  end
+            
+                  # DateTime
+                  unless method[:dateTime].nil?
+                    @html.em('Date Time: ')
+                    @html.text!(method[:dateTime])
+                    @html.br
+                  end
+            
+                  # MethodDescription
+                  unless method[:methodDescription].nil?
+                    @html.em('Method Description: ')
+                    @html.text!(method[:methodDescription])
+                    @html.br
+                  end
+            
+                  # EvaluationMethodType
+                  unless method[:evaluationMethodType].nil?
+                    @html.em('Evaluation Method Type: ')
+                    @html.text!(method[:evaluationMethodType])
+                    @html.br
+                  end
+            
+                  # DeductiveSource
+                  unless method[:deductiveSource].nil?
+                    @html.em('Deductive Source: ')
+                    @html.text!(method[:deductiveSource])
+                    @html.br
+                  end
+            
+                  # SamplingScheme
+                  unless method[:samplingScheme].nil?
+                    @html.em('Sampling Scheme: ')
+                    @html.text!(method[:samplingScheme])
+                    @html.br
+                  end
+            
+                  # LotDescription
+                  unless method[:lotDescription].nil?
+                    @html.em('Lot Description: ')
+                    @html.text!(method[:lotDescription])
+                    @html.br
+                  end
+            
+                  # SamplingRatio
+                  unless method[:samplingRatio].nil?
+                    @html.em('Sampling Ratio: ')
+                    @html.text!(method[:samplingRatio])
+                    @html.br
+                  end
+            
+                  # EvaluationProcedure
+                  unless method[:evaluationProcedure].nil? || method[:evaluationProcedure].empty?
+                    @html.details do
+                      @html.summary('Evaluation Procedure', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        citationClass.writeHtml(method[:evaluationProcedure])
+                      end
                     end
                   end
-                end
-          
-                # ReferenceDocument
-                unless method[:referenceDocument].nil? || method[:referenceDocument].empty?
-                  @html.details do
-                    @html.summary('Reference Document', {'class' => 'h5'})
-                    method[:referenceDocument].each do |doc|
-                      @html.section(class: 'block') do
-                        citationClass.writeHtml(doc)
+            
+                  # ReferenceDocument
+                  unless method[:referenceDocument].nil? || method[:referenceDocument].empty?
+                    @html.details do
+                      @html.summary('Reference Document', {'class' => 'h5'})
+                      method[:referenceDocument].each do |doc|
+                        @html.section(class: 'block') do
+                          citationClass.writeHtml(doc)
+                        end
                       end
                     end
                   end
@@ -151,47 +161,50 @@ module ADIWG
             citationClass = Html_Citation.new(@html)
             scopeClass = Html_Scope.new(@html) # Assuming there's a class to handle scope objects
           
-            conformanceResult.each do |result|
-              @html.section(class: 'block') do
-                # DateTime
-                unless result[:dateTime].nil?
-                  @html.em('Date Time: ')
-                  @html.text!(result[:dateTime])
-                  @html.br
-                end
-          
-                # Scope
-                unless result[:scope].nil?
-                  @html.details do
-                    @html.summary('Scope', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      scopeClass.writeHtml(result[:scope])
+            @html.details do
+              @html.summary('Conformance Result', {'class' => 'h5'})
+              conformanceResult.each do |result|
+                @html.section(class: 'block') do
+                  # DateTime
+                  unless result[:dateTime].nil?
+                    @html.em('Date Time: ')
+                    @html.text!(result[:dateTime])
+                    @html.br
+                  end
+            
+                  # Scope
+                  unless result[:scope].nil? || result[:scope].empty?
+                    @html.details do
+                      @html.summary('Scope', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        scopeClass.writeHtml(result[:scope])
+                      end
                     end
                   end
-                end
-          
-                # Specification (citation)
-                unless result[:specification].nil?
-                  @html.details do
-                    @html.summary('Specification', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      citationClass.writeHtml(result[:specification])
+            
+                  # Specification (citation)
+                  unless result[:specification].nil?
+                    @html.details do
+                      @html.summary('Specification', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        citationClass.writeHtml(result[:specification])
+                      end
                     end
                   end
-                end
-          
-                # Explanation
-                unless result[:explanation].nil?
-                  @html.em('Explanation: ')
-                  @html.text!(result[:explanation])
-                  @html.br
-                end
-          
-                # Pass (boolean)
-                unless result[:pass].nil?
-                  @html.em('Pass: ')
-                  @html.text!(result[:pass] ? 'Yes' : 'No')
-                  @html.br
+            
+                  # Explanation
+                  unless result[:explanation].nil?
+                    @html.em('Explanation: ')
+                    @html.text!(result[:explanation])
+                    @html.br
+                  end
+            
+                  # Pass (boolean)
+                  unless result[:pass].nil?
+                    @html.em('Pass: ')
+                    @html.text!(result[:pass] ? 'Yes' : 'No')
+                    @html.br
+                  end
                 end
               end
             end
@@ -201,63 +214,66 @@ module ADIWG
             scopeClass = Html_Scope.new(@html) # Assuming a class to handle scope objects
             spatialRepresentationClass = Html_SpatialRepresentation.new(@html) # Assuming a class to handle spatialRepresentation objects
           
-            coverageResult.each do |result|
-              @html.section(class: 'block') do
-                # DateTime
-                unless result[:dateTime].nil?
-                  @html.em('Date Time: ')
-                  @html.text!(result[:dateTime])
-                  @html.br
-                end
-          
-                # Scope
-                unless result[:scope].nil?
-                  @html.details do
-                    @html.summary('Scope', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      scopeClass.writeHtml(result[:scope])
-                    end
-                  end
-                end
-          
-                # SpatialRepresentationType
-                unless result[:spatialRepresentationType].nil?
-                  @html.em('Spatial Representation Type: ')
-                  @html.text!(result[:spatialRepresentationType])
-                  @html.br
-                end
-          
-                # SpatialRepresentation
-                unless result[:spatialRepresentation].nil?
-                  @html.details do
-                    @html.summary('Spatial Representation', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      spatialRepresentationClass.writeHtml(result[:spatialRepresentation])
-                    end
-                  end
-                end
-          
-                # ResultContent
-                unless result[:resultContent].nil? || result[:resultContent].empty?
-                  @html.em('Result Content: ')
-                  result[:resultContent].each do |content|
-                    @html.text!(content)
+            @html.details do
+              @html.summary('Coverage Result', {'class' => 'h5'})
+              coverageResult.each do |result|
+                @html.section(class: 'block') do
+                  # DateTime
+                  unless result[:dateTime].nil?
+                    @html.em('Date Time: ')
+                    @html.text!(result[:dateTime])
                     @html.br
                   end
-                end
-          
-                # ResourceFormat
-                unless result[:resourceFormat].nil?
-                  @html.em('Resource Format: ')
-                  @html.text!(result[:resourceFormat])
-                  @html.br
-                end
-          
-                # ResultFile
-                unless result[:resultFile].nil?
-                  @html.em('Result File: ')
-                  @html.text!(result[:resultFile])
-                  @html.br
+            
+                  # Scope
+                  unless result[:scope].nil? || result[:scope].empty?
+                    @html.details do
+                      @html.summary('Scope', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        scopeClass.writeHtml(result[:scope])
+                      end
+                    end
+                  end
+            
+                  # SpatialRepresentationType
+                  unless result[:spatialRepresentationType].nil? || result[:spatialRepresentationType].empty?
+                    @html.em('Spatial Representation Type: ')
+                    @html.text!(result[:spatialRepresentationType])
+                    @html.br
+                  end
+            
+                  # SpatialRepresentation
+                  unless result[:spatialRepresentation].nil? || result[:spatialRepresentation].empty?
+                    @html.details do
+                      @html.summary('Spatial Representation', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        spatialRepresentationClass.writeHtml(result[:spatialRepresentation])
+                      end
+                    end
+                  end
+            
+                  # ResultContent
+                  unless result[:resultContent].nil? || result[:resultContent].empty?
+                    @html.em('Result Content: ')
+                    result[:resultContent].each do |content|
+                      @html.text!(content)
+                      @html.br
+                    end
+                  end
+            
+                  # ResourceFormat
+                  unless result[:resourceFormat].nil?
+                    @html.em('Resource Format: ')
+                    @html.text!(result[:resourceFormat])
+                    @html.br
+                  end
+            
+                  # ResultFile
+                  unless result[:resultFile].nil?
+                    @html.em('Result File: ')
+                    @html.text!(result[:resultFile])
+                    @html.br
+                  end
                 end
               end
             end
@@ -266,30 +282,33 @@ module ADIWG
           def writeDescriptiveResult(descriptiveResult)
             scopeClass = Html_Scope.new(@html) # Assuming a class to handle scope objects
           
-            descriptiveResult.each do |result|
-              @html.section(class: 'block') do
-                # DateTime
-                unless result[:dateTime].nil?
-                  @html.em('Date Time: ')
-                  @html.text!(result[:dateTime])
-                  @html.br
-                end
-          
-                # Scope
-                unless result[:scope].nil?
-                  @html.details do
-                    @html.summary('Scope', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      scopeClass.writeHtml(result[:scope])
+            @html.details do
+              @html.summary('Descriptive Result', {'class' => 'h5'})
+              descriptiveResult.each do |result|
+                @html.section(class: 'block') do
+                  # DateTime
+                  unless result[:dateTime].nil?
+                    @html.em('Date Time: ')
+                    @html.text!(result[:dateTime])
+                    @html.br
+                  end
+            
+                  # Scope
+                  unless result[:scope].nil?
+                    @html.details do
+                      @html.summary('Scope', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        scopeClass.writeHtml(result[:scope])
+                      end
                     end
                   end
-                end
-          
-                # Statement
-                unless result[:statement].nil?
-                  @html.em('Statement: ')
-                  @html.text!(result[:statement])
-                  @html.br
+            
+                  # Statement
+                  unless result[:statement].nil?
+                    @html.em('Statement: ')
+                    @html.text!(result[:statement])
+                    @html.br
+                  end
                 end
               end
             end
@@ -298,44 +317,47 @@ module ADIWG
           def writeQuantitativeResult(quantitativeResult)
             scopeClass = Html_Scope.new(@html) # Assuming a class to handle scope objects
           
-            quantitativeResult.each do |result|
-              @html.section(class: 'block') do
-                # DateTime
-                unless result[:dateTime].nil?
-                  @html.em('Date Time: ')
-                  @html.text!(result[:dateTime])
-                  @html.br
-                end
-          
-                # Scope
-                unless result[:scope].nil?
-                  @html.details do
-                    @html.summary('Scope', {'class' => 'h5'})
-                    @html.section(class: 'block') do
-                      scopeClass.writeHtml(result[:scope])
+            @html.details do
+              @html.summary('Quantitative Result', {'class' => 'h5'})
+              quantitativeResult.each do |result|
+                @html.section(class: 'block') do
+                  # DateTime
+                  unless result[:dateTime].nil?
+                    @html.em('Date Time: ')
+                    @html.text!(result[:dateTime])
+                    @html.br
+                  end
+            
+                  # Scope
+                  unless result[:scope].nil?
+                    @html.details do
+                      @html.summary('Scope', {'class' => 'h5'})
+                      @html.section(class: 'block') do
+                        scopeClass.writeHtml(result[:scope])
+                      end
                     end
                   end
-                end
-          
-                # Value
-                unless result[:value].nil? || result[:value].empty?
-                  @html.em('Value: ')
-                  @html.text!(result[:value].join(', '))
-                  @html.br
-                end
-          
-                # ValueUnits
-                unless result[:valueUnits].nil?
-                  @html.em('Value Units: ')
-                  @html.text!(result[:valueUnits])
-                  @html.br
-                end
-          
-                # ValueRecordType
-                unless result[:valueRecordType].nil?
-                  @html.em('Value Record Type: ')
-                  @html.text!(result[:valueRecordType])
-                  @html.br
+            
+                  # Value
+                  unless result[:value].nil? || result[:value].empty?
+                    @html.em('Value: ')
+                    @html.text!(result[:value].join(', '))
+                    @html.br
+                  end
+            
+                  # ValueUnits
+                  unless result[:valueUnits].nil?
+                    @html.em('Value Units: ')
+                    @html.text!(result[:valueUnits])
+                    @html.br
+                  end
+            
+                  # ValueRecordType
+                  unless result[:valueRecordType].nil?
+                    @html.em('Value Record Type: ')
+                    @html.text!(result[:valueRecordType])
+                    @html.br
+                  end
                 end
               end
             end

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_dataQualityReport.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_dataQualityReport.rb
@@ -1,125 +1,348 @@
+require_relative 'html_citation'
 require_relative 'html_identifier'
+require_relative 'html_scope'
+require_relative 'html_spatialRepresentation'
 
 module ADIWG
-    module Mdtranslator
-      module Writers
-        module Html
-            class Html_DataQualityReport
-                def initialize(html)
-                    @html = html
-                end
+  module Mdtranslator
+    module Writers
+      module Html
+        class Html_DataQualityReport
+          def initialize(html)
+            @html = html
+          end
 
-                def writeHtml(hDataQualityReport)
-                    identifierClass = Html_Identifier.new(@html)
-
-                    # if hDataQualityReport exists it might contain any of the following:
-                    #   qualityMeasure object
-                    #   evaluationMethod object
-                    #   conformanceResult array
-                    #   coverageResult array
-                    #   descriptiveResult array
-                    #   quantitativeResult array
-
-                    # create the report object
-                    @html.details do
-                        @html.summary('Report', {'class' => 'h5'})
-                        @html.section(class: 'block') do
-
-                            # quality measure contains the following:
-                            #   identifier object
-                            #   description string
-                            #   name array of strings
-                            unless hDataQualityReport[:qualityMeasure].empty?
-                                @html.details do
-                                    @html.summary('Quality Measure', {'class' => 'h5'})
-                                    @html.section(class: 'block') do
-                                        # add the identifier
-                                        unless hDataQualityReport[:qualityMeasure][:identifier].empty?
-                                            @html.details do
-                                                @html.summary('Identifier', {'class' => 'h5'})
-                                                @html.section(class: 'block') do
-                                                    identifierClass.writeHtml(hDataQualityReport[:qualityMeasure][:identifier])
-                                                end
-                                            end
-                                        end
-                                        # add the description
-                                        unless hDataQualityReport[:qualityMeasure][:description].nil?
-                                            @html.em('Description: ')
-                                            @html.text!(hDataQualityReport[:qualityMeasure][:description])
-                                            @html.br
-                                        end
-                                        # add the names
-                                        unless hDataQualityReport[:qualityMeasure][:name].empty?
-                                            @html.em('Names: ')
-                                            @html.text!(hDataQualityReport[:qualityMeasure][:name].join('; '))
-                                            @html.br
-                                        end
-                                    end
-                                end
-                            end
-
-                            # evaluation method
-                            unless hDataQualityReport[:evaluationMethod].empty?
-                                @html.details do
-                                    @html.summary('Evaluation Method', {'class' => 'h5'})
-                                    @html.section(class: 'block') do
-                                        # TODO
-                                    end
-                                end
-                            end
-
-                            # conformance results
-                            unless hDataQualityReport[:conformanceResult].empty?
-                                @html.details do
-                                    @html.summary('Conformance Result', {'class' => 'h5'})
-                                    @html.section(class: 'block') do
-                                        # TODO
-                                    end
-                                end
-                            end
-
-                            # coverage results
-                            unless hDataQualityReport[:coverageResult].empty?
-                                @html.details do
-                                    @html.summary('Coverage Result', {'class' => 'h5'})
-                                    @html.section(class: 'block') do
-                                        # TODO
-                                    end
-                                end
-                            end
-
-                            # descriptive results
-                            unless hDataQualityReport[:descriptiveResult].empty?
-                                @html.details do
-                                    @html.summary('Descriptive Result', {'class' => 'h5'})
-                                    @html.section(class: 'block') do
-                                        # TODO
-                                    end
-                                end
-                            end
-
-                            # quantitative results
-                            unless hDataQualityReport[:quantitativeResult].empty?
-                                @html.details do
-                                    @html.summary('Quantitative Result', {'class' => 'h5'})
-                                    @html.section(class: 'block') do
-                                        # TODO
-                                    end
-                                end
-                            end
-
-                        end
-                    end
-
-                    # Return the report object
-                    # Add a return statement here if needed
-                    # Otherwise, add a comment stating that the report object is being returned
-                    return report_object
-                   
-
-                end
-
+          def writeHtml(hDataQualityReport)
+            @html.details do
+              @html.summary('Report', {'class' => 'h5'})
+              @html.section(class: 'block') do
+                writeQualityMeasure(hDataQualityReport[:qualityMeasure]) unless hDataQualityReport[:qualityMeasure].empty?
+                writeEvaluationMethod(hDataQualityReport[:evaluationMethod]) unless hDataQualityReport[:evaluationMethod].empty?
+                writeConformanceResult(hDataQualityReport[:conformanceResult]) unless hDataQualityReport[:conformanceResult].empty?
+                writeCoverageResult(hDataQualityReport[:coverageResult]) unless hDataQualityReport[:coverageResult].empty?
+                writeDescriptiveResult(hDataQualityReport[:descriptiveResult]) unless hDataQualityReport[:descriptiveResult].empty?
+                writeQuantitativeResult(hDataQualityReport[:quantitativeResult]) unless hDataQualityReport[:quantitativeResult].empty?
+              end
             end
+          end
+
+          private
+
+          def writeQualityMeasure(qualityMeasure)
+            identifierClass = Html_Identifier.new(@html)
+
+            @html.details do
+              @html.summary('Quality Measure', {'class' => 'h5'})
+              @html.section(class: 'block') do
+                # Identifier
+                unless qualityMeasure[:identifier].empty?
+                  @html.details do
+                    @html.summary('Identifier', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      identifierClass.writeHtml(qualityMeasure[:identifier])
+                    end
+                  end
+                end
+
+                # Description
+                unless qualityMeasure[:description].nil?
+                  @html.em('Description: ')
+                  @html.text!(qualityMeasure[:description])
+                  @html.br
+                end
+
+                # Names
+                unless qualityMeasure[:name].empty?
+                  @html.em('Names: ')
+                  @html.text!(qualityMeasure[:name].join('; '))
+                  @html.br
+                end
+              end
+            end
+          end
+
+          def writeEvaluationMethod(evaluationMethod)
+            citationClass = Html_Citation.new(@html)
+          
+            evaluationMethod.each do |method|
+              @html.section(class: 'block') do
+                # Type
+                unless method[:type].nil?
+                  @html.em('Type: ')
+                  @html.text!(method[:type])
+                  @html.br
+                end
+          
+                # DateTime
+                unless method[:dateTime].nil?
+                  @html.em('Date Time: ')
+                  @html.text!(method[:dateTime])
+                  @html.br
+                end
+          
+                # MethodDescription
+                unless method[:methodDescription].nil?
+                  @html.em('Method Description: ')
+                  @html.text!(method[:methodDescription])
+                  @html.br
+                end
+          
+                # EvaluationMethodType
+                unless method[:evaluationMethodType].nil?
+                  @html.em('Evaluation Method Type: ')
+                  @html.text!(method[:evaluationMethodType])
+                  @html.br
+                end
+          
+                # DeductiveSource
+                unless method[:deductiveSource].nil?
+                  @html.em('Deductive Source: ')
+                  @html.text!(method[:deductiveSource])
+                  @html.br
+                end
+          
+                # SamplingScheme
+                unless method[:samplingScheme].nil?
+                  @html.em('Sampling Scheme: ')
+                  @html.text!(method[:samplingScheme])
+                  @html.br
+                end
+          
+                # LotDescription
+                unless method[:lotDescription].nil?
+                  @html.em('Lot Description: ')
+                  @html.text!(method[:lotDescription])
+                  @html.br
+                end
+          
+                # SamplingRatio
+                unless method[:samplingRatio].nil?
+                  @html.em('Sampling Ratio: ')
+                  @html.text!(method[:samplingRatio])
+                  @html.br
+                end
+          
+                # EvaluationProcedure
+                unless method[:evaluationProcedure].nil?
+                  @html.details do
+                    @html.summary('Evaluation Procedure', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      citationClass.writeHtml(method[:evaluationProcedure])
+                    end
+                  end
+                end
+          
+                # ReferenceDocument
+                unless method[:referenceDocument].nil? || method[:referenceDocument].empty?
+                  @html.details do
+                    @html.summary('Reference Document', {'class' => 'h5'})
+                    method[:referenceDocument].each do |doc|
+                      @html.section(class: 'block') do
+                        citationClass.writeHtml(doc)
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+          
+          def writeConformanceResult(conformanceResult)
+            citationClass = Html_Citation.new(@html)
+            scopeClass = Html_Scope.new(@html) # Assuming there's a class to handle scope objects
+          
+            conformanceResult.each do |result|
+              @html.section(class: 'block') do
+                # DateTime
+                unless result[:dateTime].nil?
+                  @html.em('Date Time: ')
+                  @html.text!(result[:dateTime])
+                  @html.br
+                end
+          
+                # Scope
+                unless result[:scope].nil?
+                  @html.details do
+                    @html.summary('Scope', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      scopeClass.writeHtml(result[:scope])
+                    end
+                  end
+                end
+          
+                # Specification (citation)
+                unless result[:specification].nil?
+                  @html.details do
+                    @html.summary('Specification', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      citationClass.writeHtml(result[:specification])
+                    end
+                  end
+                end
+          
+                # Explanation
+                unless result[:explanation].nil?
+                  @html.em('Explanation: ')
+                  @html.text!(result[:explanation])
+                  @html.br
+                end
+          
+                # Pass (boolean)
+                unless result[:pass].nil?
+                  @html.em('Pass: ')
+                  @html.text!(result[:pass] ? 'Yes' : 'No')
+                  @html.br
+                end
+              end
+            end
+          end          
+
+          def writeCoverageResult(coverageResult)
+            scopeClass = Html_Scope.new(@html) # Assuming a class to handle scope objects
+            spatialRepresentationClass = Html_SpatialRepresentation.new(@html) # Assuming a class to handle spatialRepresentation objects
+          
+            coverageResult.each do |result|
+              @html.section(class: 'block') do
+                # DateTime
+                unless result[:dateTime].nil?
+                  @html.em('Date Time: ')
+                  @html.text!(result[:dateTime])
+                  @html.br
+                end
+          
+                # Scope
+                unless result[:scope].nil?
+                  @html.details do
+                    @html.summary('Scope', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      scopeClass.writeHtml(result[:scope])
+                    end
+                  end
+                end
+          
+                # SpatialRepresentationType
+                unless result[:spatialRepresentationType].nil?
+                  @html.em('Spatial Representation Type: ')
+                  @html.text!(result[:spatialRepresentationType])
+                  @html.br
+                end
+          
+                # SpatialRepresentation
+                unless result[:spatialRepresentation].nil?
+                  @html.details do
+                    @html.summary('Spatial Representation', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      spatialRepresentationClass.writeHtml(result[:spatialRepresentation])
+                    end
+                  end
+                end
+          
+                # ResultContent
+                unless result[:resultContent].nil? || result[:resultContent].empty?
+                  @html.em('Result Content: ')
+                  result[:resultContent].each do |content|
+                    @html.text!(content)
+                    @html.br
+                  end
+                end
+          
+                # ResourceFormat
+                unless result[:resourceFormat].nil?
+                  @html.em('Resource Format: ')
+                  @html.text!(result[:resourceFormat])
+                  @html.br
+                end
+          
+                # ResultFile
+                unless result[:resultFile].nil?
+                  @html.em('Result File: ')
+                  @html.text!(result[:resultFile])
+                  @html.br
+                end
+              end
+            end
+          end          
+
+          def writeDescriptiveResult(descriptiveResult)
+            scopeClass = Html_Scope.new(@html) # Assuming a class to handle scope objects
+          
+            descriptiveResult.each do |result|
+              @html.section(class: 'block') do
+                # DateTime
+                unless result[:dateTime].nil?
+                  @html.em('Date Time: ')
+                  @html.text!(result[:dateTime])
+                  @html.br
+                end
+          
+                # Scope
+                unless result[:scope].nil?
+                  @html.details do
+                    @html.summary('Scope', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      scopeClass.writeHtml(result[:scope])
+                    end
+                  end
+                end
+          
+                # Statement
+                unless result[:statement].nil?
+                  @html.em('Statement: ')
+                  @html.text!(result[:statement])
+                  @html.br
+                end
+              end
+            end
+          end          
+
+          def writeQuantitativeResult(quantitativeResult)
+            scopeClass = Html_Scope.new(@html) # Assuming a class to handle scope objects
+          
+            quantitativeResult.each do |result|
+              @html.section(class: 'block') do
+                # DateTime
+                unless result[:dateTime].nil?
+                  @html.em('Date Time: ')
+                  @html.text!(result[:dateTime])
+                  @html.br
+                end
+          
+                # Scope
+                unless result[:scope].nil?
+                  @html.details do
+                    @html.summary('Scope', {'class' => 'h5'})
+                    @html.section(class: 'block') do
+                      scopeClass.writeHtml(result[:scope])
+                    end
+                  end
+                end
+          
+                # Value
+                unless result[:value].nil? || result[:value].empty?
+                  @html.em('Value: ')
+                  @html.text!(result[:value].join(', '))
+                  @html.br
+                end
+          
+                # ValueUnits
+                unless result[:valueUnits].nil?
+                  @html.em('Value Units: ')
+                  @html.text!(result[:valueUnits])
+                  @html.br
+                end
+          
+                # ValueRecordType
+                unless result[:valueRecordType].nil?
+                  @html.em('Value Record Type: ')
+                  @html.text!(result[:valueRecordType])
+                  @html.br
+                end
+              end
+            end
+          end
+          
         end
+      end
     end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_dataQualityReport.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_dataQualityReport.rb
@@ -1,0 +1,125 @@
+require_relative 'html_identifier'
+
+module ADIWG
+    module Mdtranslator
+      module Writers
+        module Html
+            class Html_DataQualityReport
+                def initialize(html)
+                    @html = html
+                end
+
+                def writeHtml(hDataQualityReport)
+                    identifierClass = Html_Identifier.new(@html)
+
+                    # if hDataQualityReport exists it might contain any of the following:
+                    #   qualityMeasure object
+                    #   evaluationMethod object
+                    #   conformanceResult array
+                    #   coverageResult array
+                    #   descriptiveResult array
+                    #   quantitativeResult array
+
+                    # create the report object
+                    @html.details do
+                        @html.summary('Report', {'class' => 'h5'})
+                        @html.section(class: 'block') do
+
+                            # quality measure contains the following:
+                            #   identifier object
+                            #   description string
+                            #   name array of strings
+                            unless hDataQualityReport[:qualityMeasure].empty?
+                                @html.details do
+                                    @html.summary('Quality Measure', {'class' => 'h5'})
+                                    @html.section(class: 'block') do
+                                        # add the identifier
+                                        unless hDataQualityReport[:qualityMeasure][:identifier].empty?
+                                            @html.details do
+                                                @html.summary('Identifier', {'class' => 'h5'})
+                                                @html.section(class: 'block') do
+                                                    identifierClass.writeHtml(hDataQualityReport[:qualityMeasure][:identifier])
+                                                end
+                                            end
+                                        end
+                                        # add the description
+                                        unless hDataQualityReport[:qualityMeasure][:description].nil?
+                                            @html.em('Description: ')
+                                            @html.text!(hDataQualityReport[:qualityMeasure][:description])
+                                            @html.br
+                                        end
+                                        # add the names
+                                        unless hDataQualityReport[:qualityMeasure][:name].empty?
+                                            @html.em('Names: ')
+                                            @html.text!(hDataQualityReport[:qualityMeasure][:name].join('; '))
+                                            @html.br
+                                        end
+                                    end
+                                end
+                            end
+
+                            # evaluation method
+                            unless hDataQualityReport[:evaluationMethod].empty?
+                                @html.details do
+                                    @html.summary('Evaluation Method', {'class' => 'h5'})
+                                    @html.section(class: 'block') do
+                                        # TODO
+                                    end
+                                end
+                            end
+
+                            # conformance results
+                            unless hDataQualityReport[:conformanceResult].empty?
+                                @html.details do
+                                    @html.summary('Conformance Result', {'class' => 'h5'})
+                                    @html.section(class: 'block') do
+                                        # TODO
+                                    end
+                                end
+                            end
+
+                            # coverage results
+                            unless hDataQualityReport[:coverageResult].empty?
+                                @html.details do
+                                    @html.summary('Coverage Result', {'class' => 'h5'})
+                                    @html.section(class: 'block') do
+                                        # TODO
+                                    end
+                                end
+                            end
+
+                            # descriptive results
+                            unless hDataQualityReport[:descriptiveResult].empty?
+                                @html.details do
+                                    @html.summary('Descriptive Result', {'class' => 'h5'})
+                                    @html.section(class: 'block') do
+                                        # TODO
+                                    end
+                                end
+                            end
+
+                            # quantitative results
+                            unless hDataQualityReport[:quantitativeResult].empty?
+                                @html.details do
+                                    @html.summary('Quantitative Result', {'class' => 'h5'})
+                                    @html.section(class: 'block') do
+                                        # TODO
+                                    end
+                                end
+                            end
+
+                        end
+                    end
+
+                    # Return the report object
+                    # Add a return statement here if needed
+                    # Otherwise, add a comment stating that the report object is being returned
+                    return report_object
+                   
+
+                end
+
+            end
+        end
+    end
+end

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_identifier.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_identifier.rb
@@ -63,7 +63,7 @@ module ADIWG
                   end
 
                   # identifier - authority {citation}
-                  unless hIdentifier[:citation].empty?
+                  unless hIdentifier[:citation].nil?
                      @html.details do
                         @html.summary('Authority', {'id' => 'metadata-identifier', 'class' => 'h5'})
                         @html.section(:class => 'block') do

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_identifier.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_identifier.rb
@@ -63,7 +63,7 @@ module ADIWG
                   end
 
                   # identifier - authority {citation}
-                  unless hIdentifier[:citation].nil?
+                  unless hIdentifier[:citation].nil? || hIdentifier[:citation].empty?
                      @html.details do
                         @html.summary('Authority', {'id' => 'metadata-identifier', 'class' => 'h5'})
                         @html.section(:class => 'block') do

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_spatialRepresentation.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_spatialRepresentation.rb
@@ -29,7 +29,7 @@ module ADIWG
                   georeferenceableClass = Html_GeoreferenceableRepresentation.new(@html)
 
                   # spatial Representation - grid {gridRepresentation}
-                  unless hRepresentation[:gridRepresentation].empty?
+                  unless hRepresentation[:gridRepresentation].nil? || hRepresentation[:gridRepresentation].empty?
                      @html.details do
                         @html.summary('Grid Representation ', 'class' => 'h5')
                         @html.section(:class => 'block') do
@@ -39,7 +39,7 @@ module ADIWG
                   end
 
                   # spatial Representation - vector {vectorRepresentation}
-                  unless hRepresentation[:vectorRepresentation].empty?
+                  unless hRepresentation[:vectorRepresentation].nil? || hRepresentation[:vectorRepresentation].empty?
                      @html.details do
                         @html.summary('Vector Representation ', 'class' => 'h5')
                         @html.section(:class => 'block') do
@@ -49,7 +49,7 @@ module ADIWG
                   end
 
                   # spatial Representation - georectified {georectifiedRepresentation}
-                  unless hRepresentation[:georectifiedRepresentation].empty?
+                  unless hRepresentation[:georectifiedRepresentation].nil? || hRepresentation[:georectifiedRepresentation].empty?
                      @html.details do
                         @html.summary('Georectified Representation ', 'class' => 'h5')
                         @html.section(:class => 'block') do
@@ -59,7 +59,7 @@ module ADIWG
                   end
 
                   # spatial Representation - georeferenceable {georeferenceableRepresentation}
-                  unless hRepresentation[:georeferenceableRepresentation].empty?
+                  unless hRepresentation[:georeferenceableRepresentation].nil? || hRepresentation[:georeferenceableRepresentation].empty?
                      @html.details do
                         @html.summary('Georeferenceable Representation ', 'class' => 'h5')
                         @html.section(:class => 'block') do

--- a/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_coverageResult.rb
+++ b/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_coverageResult.rb
@@ -1,0 +1,27 @@
+require 'jbuilder'
+require_relative 'mdJson_scope'
+require_relative 'mdJson_spatialRepresentation'
+
+module ADIWG
+  module Mdtranslator
+    module Writers
+      module MdJson
+
+        module CoverageResult
+          def self.build(hCoverageResult)
+            Jbuilder.new do |json|
+                json.dateTime hCoverageResult[:dateTime]
+                json.scope Scope.build(hCoverageResult[:scope])
+                json.spatialRepresentationType hCoverageResult[:spatialRepresentationType]
+                json.spatialRepresentation SpatialRepresentation.build(hCoverageResult[:spatialRepresentation]) unless hCoverageResult[:spatialRepresentation].nil?
+                json.resultContent hCoverageResult[:resultContent]
+                json.resourceFormat hCoverageResult[:resourceFormat]
+                json.resultFile hCoverageResult[:resultFile]
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_dataQualityReport.rb
+++ b/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_dataQualityReport.rb
@@ -1,9 +1,9 @@
-require 'jbuilder'
-require_relative 'mdJson_conformanceResult'
-require_relative 'mdJson_descriptiveResult'
 require_relative 'mdJson_qualityMeasure'
-require_relative 'mdJson_quantitativeResult'
+require_relative 'mdJson_conformanceResult'
+require_relative 'mdJson_coverageResult'
+require_relative 'mdJson_descriptiveResult'
 require_relative 'mdJson_evaluationMethod'
+require_relative 'mdJson_quantitativeResult'
 
 module ADIWG
   module Mdtranslator
@@ -17,12 +17,12 @@ module ADIWG
           def self.build(hReport)
             Jbuilder.new do |json|
               json.type hReport[:type]
-              json.conformanceResult @Namespace.json_map(hReport[:conformanceResult], ConformanceResult) unless hReport[:conformanceResult].nil? || hReport[:conformanceResult].empty? 
-              json.descriptiveResult @Namespace.json_map(hReport[:descriptiveResult], DescriptiveResult) unless hReport[:descriptiveResult].nil? || hReport[:descriptiveResult].empty? 
-              json.evaluationMethod EvaluationMethod.build(hReport[:evaluationMethod]) unless hReport[:evaluationMethod].nil?
               json.qualityMeasure QualityMeasure.build(hReport[:qualityMeasure]) unless hReport[:qualityMeasure].nil?
+              json.conformanceResult @Namespace.json_map(hReport[:conformanceResult], ConformanceResult) unless hReport[:conformanceResult].nil? || hReport[:conformanceResult].empty? 
+              json.coverageResult @Namespace.json_map(hReport[:coverageResult], CoverageResult) unless hReport[:coverageResult].nil? || hReport[:coverageResult].empty?
+              json.descriptiveResult @Namespace.json_map(hReport[:descriptiveResult], DescriptiveResult) unless hReport[:descriptiveResult].nil? || hReport[:descriptiveResult].empty? 
+              json.evaluationMethod @Namespace.json_map(hReport[:evaluationMethod], EvaluationMethod) unless hReport[:evaluationMethod].nil? || hReport[:evaluationMethod].empty? 
               json.quantitativeResult @Namespace.json_map(hReport[:quantitativeResult], QuantitativeResult) unless hReport[:quantitativeResult].nil? || hReport[:quantitativeResult].empty? 
-
             end
           end
 

--- a/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_spatialRepresentation.rb
+++ b/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_spatialRepresentation.rb
@@ -19,10 +19,10 @@ module ADIWG
                def self.build(hSystem)
 
                   Jbuilder.new do |json|
-                     json.gridRepresentation Grid.build(hSystem[:gridRepresentation]) unless hSystem[:gridRepresentation].empty?
-                     json.vectorRepresentation Vector.build(hSystem[:vectorRepresentation]) unless hSystem[:vectorRepresentation].empty?
-                     json.georectifiedRepresentation Georectified.build(hSystem[:georectifiedRepresentation]) unless hSystem[:georectifiedRepresentation].empty?
-                     json.georeferenceableRepresentation Georeferenceable.build(hSystem[:georeferenceableRepresentation]) unless hSystem[:georeferenceableRepresentation].empty?
+                     json.gridRepresentation Grid.build(hSystem[:gridRepresentation]) unless hSystem[:gridRepresentation].nil?
+                     json.vectorRepresentation Vector.build(hSystem[:vectorRepresentation]) unless hSystem[:vectorRepresentation].nil?
+                     json.georectifiedRepresentation Georectified.build(hSystem[:georectifiedRepresentation]) unless hSystem[:georectifiedRepresentation].nil?
+                     json.georeferenceableRepresentation Georeferenceable.build(hSystem[:georeferenceableRepresentation]) unless hSystem[:georeferenceableRepresentation].nil?
                   end
 
                end # build

--- a/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_spatialRepresentation.rb
+++ b/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_spatialRepresentation.rb
@@ -19,10 +19,10 @@ module ADIWG
                def self.build(hSystem)
 
                   Jbuilder.new do |json|
-                     json.gridRepresentation Grid.build(hSystem[:gridRepresentation]) unless hSystem[:gridRepresentation].nil?
-                     json.vectorRepresentation Vector.build(hSystem[:vectorRepresentation]) unless hSystem[:vectorRepresentation].nil?
-                     json.georectifiedRepresentation Georectified.build(hSystem[:georectifiedRepresentation]) unless hSystem[:georectifiedRepresentation].nil?
-                     json.georeferenceableRepresentation Georeferenceable.build(hSystem[:georeferenceableRepresentation]) unless hSystem[:georeferenceableRepresentation].nil?
+                     json.gridRepresentation Grid.build(hSystem[:gridRepresentation]) unless hSystem[:gridRepresentation].nil? || hSystem[:gridRepresentation].empty?
+                     json.vectorRepresentation Vector.build(hSystem[:vectorRepresentation]) unless hSystem[:vectorRepresentation].nil? || hSystem[:vectorRepresentation].empty?
+                     json.georectifiedRepresentation Georectified.build(hSystem[:georectifiedRepresentation]) unless hSystem[:georectifiedRepresentation].nil? || hSystem[:georectifiedRepresentation].empty?
+                     json.georeferenceableRepresentation Georeferenceable.build(hSystem[:georeferenceableRepresentation]) unless hSystem[:georeferenceableRepresentation].nil? || hSystem[:georeferenceableRepresentation].empty?
                   end
 
                end # build


### PR DESCRIPTION
Closes #314 
Closes #260 - assuming PR #312 has also been merged

Relates to #243 

# Changes

**Changes were made to the internal metadata object**

- Increment Patch Version
- Fix Internal Object
  - fix newCoverageResult definition
  - fix newDataQualityReport definition
  - fix newStandaloneReport definition
- Cleanup & Fix Data Quality mdJson Reader
  - remove unused argmuments
  - remove unnecessary comments
  - remove undefined/unused variable
  - fix attribute names - conform to internal object
  - fix EvaluationMethod handling - array not object
- Implement Data Quality Reports HTML Writer
  - Add link for Data Quality
  - Handle empty citation object (any)
  - Refactor / format the html output for Data Quality
  - Implement all of Data Quality Reports HTML Writer
  - Handle empty citation in identifier writer
  - Handle nil representations for data quality
- Implement Data Quality Coverage Result mdJson Writer
- Fix Data Quality mdJson Reader
  - Fix missing require statements in mdJson Reader Data Quality
 - Handle nil & empty spatial representations mdJson Reader