### PR TITLE
Feature - Range Element Description

### DIFF
--- a/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
+++ b/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
@@ -519,6 +519,7 @@ class InternalMetadata
          definition: nil,
          rangeElement: []
       }
+   end
 
    def newImageDescription
       {

--- a/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
+++ b/lib/adiwg/mdtranslator/internal/internal_metadata_obj.rb
@@ -513,6 +513,13 @@ class InternalMetadata
       }
    end
 
+   def newRangeElementDescription
+      {
+         name: nil,
+         definition: nil,
+         rangeElement: []
+      }
+
    def newImageDescription
       {
          illuminationElevationAngle: nil,

--- a/lib/adiwg/mdtranslator/readers/mdJson/modules/module_rangeElementDescription.rb
+++ b/lib/adiwg/mdtranslator/readers/mdJson/modules/module_rangeElementDescription.rb
@@ -23,8 +23,8 @@ module ADIWG
               intRangeElementDescription[:definition] = hRangeElementDescription['definition']
             end
 
-            if hRangeElementDescription.has_key?('rangeElements')
-              intRangeElementDescription[:rangeElements] = hRangeElementDescription['rangeElements']
+            if hRangeElementDescription.has_key?('rangeElement')
+              intRangeElementDescription[:rangeElement] = hRangeElementDescription['rangeElement']
             end
 
             return intRangeElementDescription

--- a/lib/adiwg/mdtranslator/writers/html/sections/html_rangeElementDescription.rb
+++ b/lib/adiwg/mdtranslator/writers/html/sections/html_rangeElementDescription.rb
@@ -25,12 +25,12 @@ module ADIWG
               @html.br
             end
 
-            red[:rangeElements].each do |hRangeElement|
+            red[:rangeElement].each do |hRangeElement|
               @html.em('Range Element:')
               @html.text!(hRangeElement)
+              @html.br
             end
 
-            @html.br
           end # writeHtml
         end # Html_RangeElementDescription
         

--- a/lib/adiwg/mdtranslator/writers/iso19115_3/classes/class_rangeElementDescription.rb
+++ b/lib/adiwg/mdtranslator/writers/iso19115_3/classes/class_rangeElementDescription.rb
@@ -30,7 +30,7 @@ module ADIWG
               end
             end
 
-            hAttribute[:rangeElements].each do |hRangeElement|
+            hAttribute[:rangeElement].each do |hRangeElement|
               @xml.tag!('mrc:rangeElement') do
                 @xml.tag!('gco:Record') do
                   @xml.tag!('gco:CharacterString', hRangeElement)


### PR DESCRIPTION
Closes #320 

# Changes

*Range Element Description was originally added as part of https://github.com/adiwg/mdTranslator/pull/241 but it was not tested so the following changes were needed.*

- Add rangeElementDescription to the internal object
- Fix mdJson reader typo rangeElements -> rangeElement
- Fix html writer typo rangeElements -> rangeElement and misplaced \<br\> tag