### PR TITLE
Injection/simple html formatting

### DIFF
--- a/lib/adiwg/mdtranslator/writers/simple_html/sections/html_body.rb
+++ b/lib/adiwg/mdtranslator/writers/simple_html/sections/html_body.rb
@@ -67,36 +67,24 @@ module ADIWG
                      @html.div('id' => 'sideNav') do
 
                         # add section buttons
-                        @html.a(' Top', {'href' => '#', 'class' => 'btn'})
                         @html.a(' Contacts', {'href' => '#body-contacts', 'class' => 'btn navBtn', 'id' => 'contactButton'})
                         @html.a(' Metadata', {'href' => '#body-metadataInfo', 'class' => 'btn navBtn', 'id' => 'metadataButton'})
                         @html.a(' Resource', {'href' => '#body-resourceInfo', 'class' => 'btn navBtn', 'id' => 'resourceButton'})
                         @html.a(' Lineage', {'href' => '#body-lineage', 'class' => 'btn navBtn', 'id' => 'lineageButton'})
                         @html.a(' Distribution', {'href' => '#body-distribution', 'class' => 'btn navBtn', 'id' => 'distributionButton'})
+                        @html.br
                         @html.a(' Associated', {'href' => '#body-associatedResource', 'class' => 'btn navBtn', 'id' => 'associatedButton'})
                         @html.a(' Additional', {'href' => '#body-additionalDocument', 'class' => 'btn navBtn', 'id' => 'additionalButton'})
                         @html.a(' Dictionary', {'href' => '#body-dataDictionary', 'class' => 'btn navBtn', 'id' => 'dictionaryButton'})
                         @html.a(' Funding', {'href' => '#body-funding', 'class' => 'btn navBtn', 'id' => 'fundingButton'})
                         @html.a(' Repository', {'href' => '#body-repository', 'class' => 'btn navBtn', 'id' => 'repositoryButton'})
 
-                        # add open and close buttons
-                        @html.span(' Open', {'class' => 'btn icon-caret-down', 'id' => 'openAllButton'})
-                        @html.span(' Close', {'class' => 'btn icon-caret-right', 'id' => 'closeAllButton'})
-
                      end
 
                      # main header
                      @html.h2('id' => 'mainHeader') do
                         # added blank to span tag to force builder to create closing tag
-                        @html.span('', 'id' => 'logo')
-                        @html.span('Metadata Record')
-                        @html.span('HTML5', 'class' => 'version')
                      end
-
-                     # report title
-                     # aShortVersion = version.split('.')
-                     # shortVersion = aShortVersion[0].to_s + '.' + aShortVersion[1].to_s
-                     @html.h1('mdTranslator ' + version + ' HTML Metadata Record', 'id' => 'mdtranslator-metadata-report')
 
                      # resource citation title
                      unless hResourceInfo.empty?
@@ -110,7 +98,7 @@ module ADIWG
                      # report date
                      @html.div(:class => 'block') do
                         @html.em('Report Generated:')
-                        @html.text!(Time.new.inspect)
+                        @html.text!(Time.new.strftime('%Y-%m-%d %H:%M:%S'))
                      end
 
                      # metadata source
@@ -137,6 +125,7 @@ module ADIWG
                                  end
                               end
                               @html.hr
+                              @html.br
                            end
                         end
                      end

--- a/lib/adiwg/mdtranslator/writers/simple_html/sections/html_contact.rb
+++ b/lib/adiwg/mdtranslator/writers/simple_html/sections/html_contact.rb
@@ -70,7 +70,7 @@ module ADIWG
                         # contact - address
                         hContact[:addresses].each do |hAddress|
                            @html.div do
-                              @html.h5('Address', {'class' => 'h5'})
+                              @html.h5('Address', {'class' => 'h5', 'style' => 'font-style: italic'})
                               @html.div(:class => 'block') do
 
                                  # address - delivery points
@@ -119,7 +119,7 @@ module ADIWG
                         # contact - phones
                         hContact[:phones].each do |hPhone|
                            @html.div do
-                              @html.h5('Phone', {'class' => 'h5'})
+                              @html.h5('Phone', {'class' => 'h5', 'style' => 'font-style: italic'})
                               @html.div(:class => 'block') do
 
                                  # phone - name
@@ -159,7 +159,7 @@ module ADIWG
                         # contact - online resource []
                         hContact[:onlineResources].each do |hOnline|
                            @html.div do
-                              @html.h5('Online Resource', {'class' => 'h5'})
+                              @html.h5('Online Resource', {'class' => 'h5', 'style' => 'font-style: italic'})
                               @html.div(:class => 'block') do
                                  onlineClass.writeHtml(hOnline)
                               end
@@ -169,7 +169,7 @@ module ADIWG
                         # contact - logos []
                         hContact[:logos].each do |hLogo|
                            @html.div do
-                              @html.h5('Logo Graphic', {'class' => 'h5'})
+                              @html.h5('Logo Graphic', {'class' => 'h5', 'style' => 'font-style: italic'})
                               @html.div(:class => 'block') do
                                  graphicClass.writeHtml(hLogo)
                               end
@@ -194,7 +194,7 @@ module ADIWG
                         if hContact.key?(:externalIdentifier) && !hContact[:externalIdentifier].empty?
                            hContact[:externalIdentifier].each do |identifier|
                               @html.div do
-                                 @html.h5("External Identifier", {'class' => 'h5'})
+                                 @html.h5("External Identifier", {'class' => 'h5', 'style' => 'font-style: italic'})
                                  @html.div(:class => 'block') do
                                     @html.em('Identifier: ')
                                     @html.text!(identifier[:identifier])

--- a/lib/adiwg/mdtranslator/writers/simple_html/sections/html_keyword.rb
+++ b/lib/adiwg/mdtranslator/writers/simple_html/sections/html_keyword.rb
@@ -32,20 +32,7 @@ module ADIWG
                      end
                      @html.h5(type, {'class' => 'h5'})
                      @html.div(:class => 'block') do
-
-                        # keywords
-                        @html.ul do
-                           hKeyword[:keywords].each do |hKeyword|
-                              unless hKeyword[:keyword].nil?
-                                 keyword = hKeyword[:keyword]
-                                 unless hKeyword[:keywordId].nil?
-                                    keyword += ' (ID: ' + hKeyword[:keywordId].to_s + ')'
-                                 end
-                                 @html.li(keyword)
-                              end
-                           end
-                        end
-
+                        
                         # thesaurus
                         unless hKeyword[:thesaurus].empty?
                            @html.div do
@@ -53,6 +40,17 @@ module ADIWG
                               @html.div(:class => 'block') do
                                  citationClass.writeHtml(hKeyword[:thesaurus])
                               end
+                           end
+                        end
+
+                        # keywords
+                        hKeyword[:keywords].each do |hKeyword|
+                           unless hKeyword[:keyword].nil?
+                              keyword = hKeyword[:keyword]
+                              unless hKeyword[:keywordId].nil?
+                                 keyword += ' (ID: ' + hKeyword[:keywordId].to_s + ')'
+                              end
+                              @html.div('Keyword:' + keyword)
                            end
                         end
 

--- a/lib/adiwg/mdtranslator/writers/simple_html/sections/html_metadataInfo.rb
+++ b/lib/adiwg/mdtranslator/writers/simple_html/sections/html_metadataInfo.rb
@@ -50,7 +50,7 @@ module ADIWG
                   # metadataInfo - metadata identifier {identifier}
                   unless hMetaInfo[:metadataIdentifier].empty?
                      @html.div do
-                        @html.h3('Metadata Identifier', {'id' => 'metadataInfo-identifier', 'class' => 'h3'})
+                        @html.h3('Metadata Identifier', {'id' => 'metadataInfo-identifier', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            identifierClass.writeHtml(hMetaInfo[:metadataIdentifier])
                         end
@@ -60,7 +60,7 @@ module ADIWG
                   # metadataInfo - parent metadata {citation}
                   unless hMetaInfo[:parentMetadata].empty?
                      @html.div do
-                        @html.h3('Parent Metadata', {'id' => 'metadataInfo-parent', 'class' => 'h3'})
+                        @html.h3('Parent Metadata', {'id' => 'metadataInfo-parent', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            citationClass.writeHtml(hMetaInfo[:parentMetadata])
                         end
@@ -70,7 +70,7 @@ module ADIWG
                   # metadataInfo - metadata locales
                   unless hMetaInfo[:defaultMetadataLocale].empty? && hMetaInfo[:otherMetadataLocales].empty?
                      @html.div do
-                        @html.h3('Metadata Locales', {'id' => 'metadataInfo-locale', 'class' => 'h3'})
+                        @html.h3('Metadata Locales', {'id' => 'metadataInfo-locale', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
 
                            # default metadata locales {locale}
@@ -100,7 +100,7 @@ module ADIWG
                   # metadataInfo - contacts [] {responsibility}
                   unless hMetaInfo[:metadataContacts].empty?
                      @html.div do
-                        @html.h3('Metadata Contacts', {'id' => 'metadataInfo-contacts', 'class' => 'h3'})
+                        @html.h3('Metadata Contacts', {'id' => 'metadataInfo-contacts', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            hMetaInfo[:metadataContacts].each do |hResponsibility|
                               @html.div do
@@ -117,7 +117,7 @@ module ADIWG
                   # metadataInfo - dates [] {date}
                   unless hMetaInfo[:metadataDates].empty?
                      @html.div do
-                        @html.h3('Metadata Dates', {'id' => 'metadataInfo-dates', 'class' => 'h3'})
+                        @html.h3('Metadata Dates', {'id' => 'metadataInfo-dates', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            hMetaInfo[:metadataDates].each do |hDate|
                               @html.em('Date: ')
@@ -131,7 +131,7 @@ module ADIWG
                   # metadataInfo - linkages [] {onlineResource}
                   unless hMetaInfo[:metadataLinkages].empty?
                      @html.div do
-                        @html.h3('Metadata Online Resource', {'id' => 'metadataInfo-links', 'class' => 'h3'})
+                        @html.h3('Metadata Online Resource', {'id' => 'metadataInfo-links', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            hMetaInfo[:metadataLinkages].each do |hOnline|
                               @html.div do
@@ -148,7 +148,7 @@ module ADIWG
                   # metadataInfo - constraints [] {constraint}
                   unless hMetaInfo[:metadataConstraints].empty?
                      @html.div do
-                        @html.h3('Metadata Constraints', {'id' => 'metadataInfo-constraint', 'class' => 'h3'})
+                        @html.h3('Metadata Constraints', {'id' => 'metadataInfo-constraint', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            hMetaInfo[:metadataConstraints].each do |hConstraint|
                               @html.div do
@@ -165,7 +165,7 @@ module ADIWG
                   # metadataInfo - maintenance {maintenance}
                   unless hMetaInfo[:metadataMaintenance].empty?
                      @html.div do
-                        @html.h3('Metadata Maintenance', {'id' => 'metadataInfo-maintenance', 'class' => 'h3'})
+                        @html.h3('Metadata Maintenance', {'id' => 'metadataInfo-maintenance', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            maintClass.writeHtml(hMetaInfo[:metadataMaintenance])
                         end
@@ -175,13 +175,14 @@ module ADIWG
                   # metadataInfo - alternate metadata references [] {citation}
                   unless hMetaInfo[:alternateMetadataReferences].empty?
                      @html.div do
-                        @html.h3('Alternate Metadata Citations', {'id' => 'metadataInfo-alternate', 'class' => 'h3'})
+                        @html.h3('Alternate Metadata Citations', {'id' => 'metadataInfo-alternate', 'class' => 'h3', 'style' => 'font-style: italic'})
                         @html.div(:class => 'block') do
                            hMetaInfo[:alternateMetadataReferences].each do |hCitation|
                               @html.div do
                                  @html.div(hCitation[:title], 'class' => 'h5')
                                  @html.div(:class => 'block') do
                                     citationClass.writeHtml(hCitation)
+                                    @html.br
                                  end
                               end
                            end

--- a/lib/adiwg/mdtranslator/writers/simple_html/sections/html_timePeriod.rb
+++ b/lib/adiwg/mdtranslator/writers/simple_html/sections/html_timePeriod.rb
@@ -64,9 +64,7 @@ module ADIWG
                   # time period - description
                   unless hPeriod[:description].nil?
                      @html.em('Description: ')
-                     @html.div(:class => 'block') do
-                        @html.text!(hPeriod[:description])
-                     end
+                     @html.text!(hPeriod[:description])
                   end
 
                   # time period - start geologic age {geologic age}


### PR DESCRIPTION
## Changes
- Removed unnecessary buttons on top of document
- Formatted datetime string to second-level precision
- Added new line separator in contacts
- Italic style for headers found in html_contact
- Changed order of thesaurus and keywords
- added `Keyword:` prefix to keywords and removed list component
- Italic style for headers found in html_metadataInfo
- removed new line in htmll_timePeriod description