### PR TITLE
Add primaryITInvestmentUII in DCAT-US writer

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
@@ -18,6 +18,7 @@ require_relative 'dcat_us_references'
 require_relative 'dcat_us_landing_page'
 require_relative 'dcat_us_system_of_records'
 require_relative 'dcat_us_description'
+require_relative 'dcat_us_primaryITInvestmentUII'
 
 module ADIWG
    module Mdtranslator
@@ -49,6 +50,7 @@ module ADIWG
                references = References.build(intObj)
                landingPage = LandingPage.build(intObj)
                systemOfRecords = SystemOfRecords.build(intObj)
+               primaryITInvestmentUII = PrimaryITInvestmentUII.build(intObj)
 
                @Namespace = ADIWG::Mdtranslator::Writers::Dcat_us
 
@@ -80,7 +82,7 @@ module ADIWG
                   json.set!('landingPage', landingPage)
                   json.set!('isPartOf', isPartOf)
                   json.set!('systemOfRecords', systemOfRecords)
-                  json.set!('primaryITInvestmentUII', metadataInfo[:metadataIdentifier])
+                  json.set!('primaryITInvestmentUII', primaryITInvestmentUII)
                   json.set!('describedBy', describedBy)
                   # json.set!('describedByType', metadataInfo[:metadataOnlineOptions][0][:olResProtocol])
                   # json.set!('conformsTo', metadataInfo[:metadataStandards][0][:standardName])

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
@@ -80,7 +80,7 @@ module ADIWG
                   json.set!('landingPage', landingPage)
                   json.set!('isPartOf', isPartOf)
                   json.set!('systemOfRecords', systemOfRecords)
-                  # json.set!('primaryITInvestmentUII', metadataInfo[:metadataId])
+                  json.set!('primaryITInvestmentUII', metadataInfo[:metadataIdentifier])
                   json.set!('describedBy', describedBy)
                   # json.set!('describedByType', metadataInfo[:metadataOnlineOptions][0][:olResProtocol])
                   # json.set!('conformsTo', metadataInfo[:metadataStandards][0][:standardName])

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_primaryITInvestmentUII.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_primaryITInvestmentUII.rb
@@ -1,0 +1,19 @@
+require 'jbuilder'
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module Dcat_us
+            module PrimaryITInvestmentUII
+
+               def self.build(intObj)
+                  primaryITInvestmentUII = intObj[:metadata][:metadataInfo][:metadataIdentifier][:identifier]
+                  
+                  primaryITInvestmentUII ? primaryITInvestmentUII : nil
+                end
+                
+            end
+         end
+      end
+   end
+end


### PR DESCRIPTION
# Changes
- Add support for primaryITInvestmentUII that retrieves the Identifier object from `metadataInfo.metadataIdentifier`
