### PR TITLE
Add AccessURL, DownloadURL, and MediaType modules to DCAT-US writer

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_access_url.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_access_url.rb
@@ -1,0 +1,17 @@
+require 'jbuilder'
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module Dcat_us
+            module AccessURL
+
+               def self.build(option)
+                  option[:olResURI] if option[:olResURI].end_with?('.html')
+                end                
+
+            end
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -1,4 +1,8 @@
 require 'jbuilder'
+require_relative 'dcat_us_access_url'
+require_relative 'dcat_us_download_url'
+require_relative 'dcat_us_media_type'
+
 
 module ADIWG
   module Mdtranslator
@@ -7,6 +11,7 @@ module ADIWG
         module Distribution
 
           def self.build(intObj)
+
             resourceDistributions = intObj.dig(:metadata, :distributorInfo)
             distributions = []
 
@@ -20,13 +25,12 @@ module ADIWG
                 distributor[:transferOptions]&.each do |transfer|
                   break if break_flag
 
-                  mediaType = transfer.dig(:distributionFormats)&.find { |format| format.dig(:formatSpecification, :title) }&.dig(:formatSpecification, :title) || ''
+                  mediaType = MediaType.build(transfer)
 
                   transfer[:onlineOptions]&.each do |option|
                     next unless option[:olResURI]
-
-                    accessURL = option[:olResURI] unless option[:olResURI].end_with?('.html')
-                    downloadURL = option[:olResURI] if option[:olResURI].end_with?('.html')
+                    accessURL = AccessURL.build(option)
+                    downloadURL = DownloadURL.build(option)
                     title = option[:olResName] || ''
 
                     distribution = Jbuilder.new do |json|

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_download_url.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_download_url.rb
@@ -1,0 +1,17 @@
+require 'jbuilder'
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module Dcat_us
+            module DownloadURL
+
+               def self.build(option)
+                  option[:olResURI] unless option[:olResURI].end_with?('.html')
+                end                
+
+            end
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_media_type.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_media_type.rb
@@ -1,0 +1,17 @@
+require 'jbuilder'
+
+module ADIWG
+   module Mdtranslator
+      module Writers
+         module Dcat_us
+            module MediaType
+
+               def self.build(transfer)
+                  transfer.dig(:distributionFormats)&.find { |format| format.dig(:formatSpecification, :title) }&.dig(:formatSpecification, :title) || ''
+                end                
+
+            end
+         end
+      end
+   end
+end

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -16,7 +16,7 @@ class TestWriterDcatUsDistribution < TestWriterDcatUsParent
       hJsonOut = JSON.parse(metadata[:writerOutput])
       got = hJsonOut['distribution']
 
-      expect = [{"@type"=>"dcat:Distribution", "description"=>"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.", "accessURL"=>"http://ISO.uri/adiwg/0", "mediaType"=>"CSV", "title"=>""}]
+      expect = [{"@type"=>"dcat:Distribution", "description"=>"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.", "downloadURL"=>"http://ISO.uri/adiwg/0", "mediaType"=>"CSV", "title"=>""}]
 
       assert_equal expect, got
    end


### PR DESCRIPTION
## Changes
- Break out accessURL, downloadURL, and mediaType to their own classes
- changed return of accessURL if html exists and downloadURL if not