### PR TITLE
Bump adiwg-mdtranslator version to 2.20.0-beta.10 and update dictionaryId handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adiwg-mdtranslator (2.20.0.pre.beta.6)
+    adiwg-mdtranslator (2.20.0.pre.beta.10)
       adiwg-mdcodes (= 2.10.1)
       adiwg-mdjson_schemas (= 2.10.1)
       builder (~> 3.2)

--- a/lib/adiwg/mdtranslator/version.rb
+++ b/lib/adiwg/mdtranslator/version.rb
@@ -109,7 +109,7 @@
 module ADIWG
    module Mdtranslator
       # current mdtranslator version
-      VERSION = "2.20.0-beta.6"
+      VERSION = "2.20.0-beta.10"
    end
 end
 

--- a/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_dictionary.rb
+++ b/lib/adiwg/mdtranslator/writers/mdJson/sections/mdJson_dictionary.rb
@@ -24,7 +24,7 @@ module ADIWG
                def self.build(hDictionary)
 
                   Jbuilder.new do |json|
-                     json.dictionaryId hDictionary[:dictionaryId] unless hDictionary[:dictionaryId].empty?
+                     json.dictionaryId hDictionary[:dictionaryId]
                      json.citation Citation.build(hDictionary[:citation]) unless hDictionary[:citation].empty?
                      json.description hDictionary[:description]
                      json.subject hDictionary[:subjects] unless hDictionary[:subjects].empty?


### PR DESCRIPTION
Update the adiwg-mdtranslator version to 2.20.0-beta.10 and refine the handling of dictionaryId in the JSON output.